### PR TITLE
Release v2.1.0

### DIFF
--- a/.noserc
+++ b/.noserc
@@ -1,0 +1,2 @@
+[nosetests]
+testmatch = ((\b|_)tests?|(\b|[a-zA-Z])Tests?)\Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change History of intercom_test
 
+## v2.1.0
+
+* Updated the dependency on PyYAML to allow compatibility with newer versions that are not listed as vulnerable to CVE-2017-18342.
+* Added a `hjx-stubber` subcommand to `icy-test` that simplifies testing HTTP-exchanged JSON documents in non-Python environments.
+* Added support for testing Serverless HTTP API service provider projects targeting AWS.
+
+---
+
 ## v2.0.1
 
 * Fixed a typo relating to safe loading of YAML in augmentation data update files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,12 @@ Contributing to intercom_test
 
 The following is a set of guidelines for contributing to this project.  These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
 
+## Unit Tests
+
+`Development` is a requirements.txt-style file meant to be `pip install`-ed from the root directory of the project.  It will install the `intercom_test` package from the project directory in development mode as well as the development tools needed for running the tests in the repository and other project-related tasks (like coverage reporting).
+
+`intercom_test` is set up to be tested with [nose][nose-package] via `bin/sniff.sh`.  This small bash script may have useful comments about arguments that can be passed.
+
 ## Code Review
 
 All pull requests will be reviewed by one or more of the Senior Engineers at PayTrace. As of 2018-October-21, those users are:
@@ -22,3 +28,7 @@ Obviously for such larger changes, there may be a delay in reviewing/merging if 
 ## Help us help you!
 
 We highly recommend [allowing edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) (ie, us) to your branch. Since intercom_test is actively developed, there's a good chance that other pull requests will have been merged in between when you submit a pull request and when we approve it. Allowing us to edit your branch means that we can rebase and fix any merge conflicts for you.
+
+
+
+[nose-package]: https://pypi.org/project/nose/

--- a/Development
+++ b/Development
@@ -1,0 +1,9 @@
+# A requirements.txt-style file for development dependencies
+
+# Bring this library in via development-install
+-e .
+
+# Development/testing dependencies
+nose ~=1.3
+coverage ~=5.3
+should_dsl ~=2.1

--- a/README.md
+++ b/README.md
@@ -69,11 +69,6 @@ This essentially means distributing the test cases through multiple files.  *int
 When this package is installed with the `[cli]` extra, it makes a command line tool called `icy-test` available to access the core functionality of `intercom_test`, facilitating use of this functionality in languages other than Python.  Help on use of the tool can be obtained by running `icy-test --help`.
 
 
-## CVE-2017-18342
-
-This package allows the latest major released version of *PyYAML* at the time of publication, 3.13.  The PyYAML team has long debated a breaking change to make `yaml.load` a "safe" operation vs. it's current arbitrary code execution vulnerability.  *intercom_test* supports `safe_loading` in several places (as a keyword argument or an object property) -- defaulting to `True` -- to allow reversion to vulnerable behavior for any client code choosing that burden.  By default, *intercom_test* now only uses "safe" YAML loading.  Unfortunately, until a new major version of *PyYAML* is released addressing the default-unsafe API indicated by this CVE, *intercom_test* cannot publish a version compatible with the new API.
-
-
 ## Contributing
 
 1. Fork it ( https://github.com/PayTrace/intercom_test )

--- a/bin/sniff.sh
+++ b/bin/sniff.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Coverage: --with-coverage --cover-html --cover-html-dir=coverage --cover-package=intercom_test
+
+NOSE_TESTMATCH='((\b|_)tests?|(\b|[a-zA-Z])Tests?)' nosetests "${@}"

--- a/docs/Requirements.txt
+++ b/docs/Requirements.txt
@@ -1,1 +1,3 @@
+sphinx>=1.8.1, <2
 sphinx-rtd-theme==0.4.2
+-e ..

--- a/docs/source/aws-serverless.rst
+++ b/docs/source/aws-serverless.rst
@@ -1,0 +1,74 @@
+==================================================
+Support for Testing Serverless API Services on AWS
+==================================================
+
+Many API services are currently hosted on AWS, and `Serverless`_ is one common
+Infrastructure-as-Code (IaC) system for organizing the bevy of resources
+necessary for a "serverless" service.  Custom code for handling API requests in
+a Serverless application is integrated through Lambda Functions, which have a
+simple call interface in several languages.  Where the language chosen is
+Python, using the :doc:`intercom_test package </index>` allows development of
+the interface test cases in familiar HTTP terms but, through
+:py:class:`intercom_test.aws_http.ServerlessHandlerMapper`, allows the Lambda
+handler functions to be tested.
+
+Extended Example
+----------------
+
+.. figure:: example_project_structure.png
+   :width: 9cm
+   
+   Example directory tree for using :py:mod:`intercom_test`
+
+Building on the :doc:`base example </index>`, if we had a ``serverless.yml``
+file in the ``src`` directory, we could create test code like::
+  
+    from contextlib import ExitStack
+    
+    from unittest import TestCase
+    from intercom_test import InterfaceCaseProvider, HTTPCaseAugmenter, aws_http
+    
+    def around_interface_case(case):
+        with ExitStack() as env:
+            # TODO: Build environment through `env.enter_context(...)` calls
+            # to reflect the expectations of *case*:
+            #
+            #   * Populate the database with expected data
+            #   * Stub external services with expected request/response pairs
+            
+            yield
+    
+    class InterfaceTests(TestCase):
+        def test_interface_case(self):
+            # Construct an AWS Lambda handler function mapper from a Serverless
+            # configuration (targeting the "aws" provider)
+            service = aws_http.ServerlessHandlerMapper("src")
+            
+            # Get the case-testing callable, which accepts an entry (a dict)
+            # from the test data file(s)
+            case_tester = service.case_tester(case_env=around_interface_case)
+            
+            # Construct the case provider
+            case_provider = InterfaceCaseProvider(
+                "test/component_interfaces", "service",
+                case_augmenter=HTTPCaseAugmenter("test/component_test_env/service")
+            )
+            
+            # Use case_provider to construct a generator of case runner callables
+            case_runners = case_provider.case_runners(case_tester)
+            
+            for i, run_test in enumerate(case_runners):
+                with self.subTest(i=i):
+                    run_test()
+    
+    if __name__ == '__main__':
+        unittest.main()
+
+The callable returned from :py:meth:`intercom_test.aws_http.ServerlessHandlerMapper.case_tester`
+accepts a :py:class:`dict` of test case data, some keys in which have special
+meaning (see :py:func:`intercom_test.aws_http.ala_http_api`).  It does not care
+where this :py:class:`dict` comes from, but a
+:py:class:`intercom_test.framework.InterfaceCaseProvider` is specifically
+designed to provide that.
+
+.. _Serverless: https://www.serverless.com

--- a/docs/source/aws-serverless.rst
+++ b/docs/source/aws-serverless.rst
@@ -26,17 +26,17 @@ file in the ``src`` directory, we could create test code like::
     from contextlib import ExitStack
     
     from unittest import TestCase
-    from intercom_test import InterfaceCaseProvider, HTTPCaseAugmenter, aws_http
+    from intercom_test import InterfaceCaseProvider, HTTPCaseAugmenter, aws_http, utils as icy_utils
     
-    def around_interface_case(case):
-        with ExitStack() as env:
-            # TODO: Build environment through `env.enter_context(...)` calls
-            # to reflect the expectations of *case*:
-            #
-            #   * Populate the database with expected data
-            #   * Stub external services with expected request/response pairs
-            
-            yield
+    @icy_utils.complex_test_context
+    def around_interface_case(case, setup):
+        setup(database(case))
+        setup(stubs(case))
+        
+        yield
+    
+    # ... define `database` and `stubs` to return context managers for the
+    # test case data they are given ...
     
     class InterfaceTests(TestCase):
         def test_interface_case(self):

--- a/docs/source/aws-serverless.rst
+++ b/docs/source/aws-serverless.rst
@@ -9,7 +9,7 @@ a Serverless application is integrated through Lambda Functions, which have a
 simple call interface in several languages.  Where the language chosen is
 Python, using the :doc:`intercom_test package </index>` allows development of
 the interface test cases in familiar HTTP terms but, through
-:py:class:`intercom_test.aws_http.ServerlessHandlerMapper`, allows the Lambda
+:py:class:`~intercom_test.aws_http.ServerlessHandlerMapper`, allows the Lambda
 handler functions to be tested.
 
 Extended Example
@@ -65,10 +65,15 @@ file in the ``src`` directory, we could create test code like::
         unittest.main()
 
 The callable returned from :py:meth:`intercom_test.aws_http.ServerlessHandlerMapper.case_tester`
-accepts a :py:class:`dict` of test case data, some keys in which have special
-meaning (see :py:func:`intercom_test.aws_http.ala_http_api`).  It does not care
-where this :py:class:`dict` comes from, but a
+accepts a :py:class:`dict` of test case data.  It does not care where this
+:py:class:`dict` comes from, but an
 :py:class:`intercom_test.framework.InterfaceCaseProvider` is specifically
-designed to provide that.
+designed to provide such a value.
+
+Certain keys of the test case :class:`dict` are consulted (documented in
+:py:class:`intercom_test.aws_http.HttpCasePreparer`) when building the event
+passed to the handler function, and certain other keys (documented in
+:py:func:`intercom_test.aws_http.confirm_expected_response`) are used for
+evaluating correctness of the handler function's result.
 
 .. _Serverless: https://www.serverless.com

--- a/docs/source/icy-test.rst
+++ b/docs/source/icy-test.rst
@@ -62,4 +62,39 @@ Use the ``icy-test mergecases`` subcommand to invoke
 with appropriate setup taken from the ``icy-test`` configuration file.
 
 
+Access HTTP JSON Exchange Stubs Outside Python
+----------------------------------------------
+
+Because solutions involving exchanges of JSON documents over HTTP are becoming
+very popular, ``icy-test`` provides a subcommand to offload the logic of
+matching the elements of the HTTP request (method, URL (path and query string),
+and sometimes request body) with a test case.  Moreover,
+``icy-test hjx-stubber`` will, when given a request that *doesn't* exist in the
+test case set, respond with information on how the request can be changed to
+one that is in the test case set.
+
+If changing the method, URL, and request body do not provide enough dimensions
+of control to adequately represent the gamut of request/response pairs for
+the represented service, ``icy-test hjx-stubber`` does reference the
+``request keys`` configuration file entry, which can be used to add fields to
+the "test case key."  An example would be listing ``story`` as a request key,
+then populating test cases that share the same method, URL, and request body
+with individual values for the the ``story`` field.  To fully implement this,
+the interface-consuming project has to be willing to inject a ``story`` field
+into the request line passed to ``icy-test hjx-stubber`` during testing.
+
+``icy-test hjx-stubber`` accepts a request formatted as a JSON object on a
+single line (i.e. `JSON Lines`_), where at least ``method`` and ``url``
+properties are present.  It will respond with a similar `JSON Lines`_ object
+which is either the full, matching test case (plus a ``response status`` field
+if one was not specified in the data files) or a set of diffs for the closest
+test cases ``icy-test hjx-stubber`` could find in the whole case set.  See
+``icy-test hjx-stubber --help`` for more information.
+
+Starting up ``icy-test hjx-stubber`` is somewhat expensive for large sets of
+test cases, so it is best to start it when spinning up the test environment for
+a run of tests, then shut it down when testing finishes.  Closing standard
+input is enough to get the program to exit.
+
+
 .. _JSON Lines: http://jsonlines.org

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ Welcome to intercom_test's documentation!
    
    modules
    icy-test
+   aws-serverless
 
 
 Using This Package

--- a/lib/intercom_test/augmentation/compact_file.py
+++ b/lib/intercom_test/augmentation/compact_file.py
@@ -24,6 +24,7 @@ from ..utils import def_enum
 from ..yaml_tools import (
     content_events as _yaml_content_events,
     value_from_event_stream as _yaml_value_from_events,
+    get_load_fn as _get_yaml_loader,
 )
 
 class CaseIndexer:
@@ -158,7 +159,7 @@ def case_keys(data_file):
 
 def augment_dict_from(d, file_ref, case_key, *, safe_loading=True):
     file, start_byte = file_ref
-    load_yaml = yaml.safe_load if safe_loading else yaml.load
+    load_yaml = _get_yaml_loader(safe=safe_loading)
     with open(file) as stream:
         if start_byte is None:
             for k, v in load_yaml(stream)[case_key].items():
@@ -204,7 +205,7 @@ class TestCaseAugmenter:
                 ).augmentation_data_events()
     
     def _load_yaml(self, stream):
-        load_yaml = yaml.safe_load if self.safe_loading else yaml.load
+        load_yaml = _get_yaml_loader(safe=self.safe_loading)
         return load_yaml(stream)
 
 class Updater:

--- a/lib/intercom_test/augmentation/update_file.py
+++ b/lib/intercom_test/augmentation/update_file.py
@@ -32,6 +32,7 @@ from ..yaml_tools import (
     YAML_EXT,
     content_events as _yaml_content_events,
     value_from_event_stream as _value_from_events,
+    get_load_fn as _get_yaml_loader,
 )
 
 class Indexer:
@@ -336,5 +337,5 @@ class TestCaseAugmenter:
                 ).augmentation_data_events()
     
     def _load_yaml(self, stream):
-        load_yaml = yaml.safe_load if self.safe_loading else yaml.load
+        load_yaml = _get_yaml_loader(safe=self.safe_loading)
         return load_yaml(stream)

--- a/lib/intercom_test/aws_http.py
+++ b/lib/intercom_test/aws_http.py
@@ -375,11 +375,7 @@ def ala_rest_api(handler_mapper: HandlerMapper, context: Optional[dict] = None, 
     if context is None:
         context = {}
     
-    # TODO: case_env = _case_env_contextmanager(case_env)
-    if inspect.isgeneratorfunction(case_env):
-        case_env = contextlib.contextmanager(case_env)
-    elif case_env is None:
-        case_env = lambda _: _nullcontext()
+    case_env = _case_env_contextmanager(case_env)
     
     def tester(case):
         input_key = 'AWS Lambda input'
@@ -506,11 +502,7 @@ def ala_http_api(handler_mapper: HandlerMapper, context: Optional[dict] = None, 
     if context is None:
         context = {}
     
-    # TODO: case_env = _case_env_contextmanager(case_env)
-    if inspect.isgeneratorfunction(case_env):
-        case_env = contextlib.contextmanager(case_env)
-    elif case_env is None:
-        case_env = lambda _: _nullcontext()
+    case_env = _case_env_contextmanager(case_env)
     
     def tester(case):
         input_key = 'AWS Lambda input'
@@ -609,6 +601,15 @@ def _http_conformed_result(result: OneOf[Mapping, str, Iterable]) -> dict:
             "Content-Type": "application/json",
         },
     )
+
+def _case_env_contextmanager(case_env):
+    if case_env is None:
+        return lambda _: _nullcontext()
+    
+    if not inspect.isgeneratorfunction(case_env):
+        return case_env
+    
+    return contextlib.contextmanager(case_env)
 
 def _build_aws_event_body(request_body: OneOf[str, bytes, list, dict], aws_event: dict) -> None:
     """Modify the AWS Lambda input event based on request body

--- a/lib/intercom_test/aws_http.py
+++ b/lib/intercom_test/aws_http.py
@@ -1,0 +1,179 @@
+"""Module for adapting HTTP requests to AWS API Gateway events"""
+
+from abc import ABC, abstractmethod
+from base64 import b64encode, b64decode
+import contextlib
+import inspect
+import json
+from pathlib import Path
+import subprocess as subp
+from typing import Any, Callable, Optional, Union as OneOf
+from urllib.parse import urlparse, parse_qsl
+
+AwsLambdaHandler = Callable[[dict, dict], dict]
+
+class NoRouteError(Exception):
+    """Raised to indicate no route matched the given method and path"""
+    def __init__(self, method: str, path: str):
+        super().__init__(f"{method.upper()} {path}")
+        self.method = method.upper()
+        self.path = path
+
+class HandlerMapper(ABC):
+    """Abstract base class for classes that can map HTTP requests to handlers"""
+    @abstractmethod
+    def map(self, method: str, path: str) -> AwsLambdaHandler:
+        raise Exception("pure abstract method called")
+
+class FunctionalHandlerMapper(HandlerMapper):
+    def __init__(self, mapper: Callable[[str, str], AwsLambdaHandler]):
+        super().__init__()
+        self._mapper = mapper
+    
+    def map(self, method: str, path: str) -> AwsLambdaHandler:
+        return self._mapper(method, path)
+
+class ServerlessHandlerMapper(HandlerMapper):
+    PROJECT_FILE = 'serverless.yml'
+    
+    def __init__(self, project_dir):
+        super().__init__()
+        self._project_dir = Path(project_dir)
+    
+    def map(self, method: str, path: str) -> AwsLambdaHandler:
+        if not hasattr(self, '_routing'):
+            self._build_routing()
+        
+        for pred, handler in self._routing:
+            if pred(method, path):
+                return handler
+        
+        raise NoRoute(method, path)
+    
+    def case_tester(self, api_style: OneOf[str, ApiAdapter], **kwargs):
+        if isinstance(api_style, str):
+            api_style = globals()[f"ala_{api_style}_api"]
+        
+        return api_style(self, **kwargs)
+    
+    def _build_routing(self, ):
+        """Call 'serverless print' and pull out resource-to-handler routing"""
+        
+        raise Exception("not implemented")
+
+def ala_rest_api(handler_mapper: HandlerMapper, context: Optional[dict] = None, case_env=None) -> Callabe[[dict], None]:
+    """Build a case tester from a :class:`HandlerMapper`
+    
+    :param handler_mapper: maps from method and path to an AWS Lambda handler function
+    :param context: optional context information to pass to the identified handler
+    :param case_env: context function for setup/teardown with access to the test case
+    
+    The *case_env* (if given) must be either a generator function that yields
+    a single time or a callable returning a *context manager*.  If a generator
+    function is given, it is converted to a context manager constructor with
+    :func:`contextlib.contextmanager`.  In either case, the context manager
+    constructor is invoked with the test case data :class:`dict` around
+    invocation of the handler callable.
+    """
+    if context is None:
+        context = {}
+    
+    if inspect.isgeneratorfunction(case_env):
+        case_env = contextlib.contextmanager(case_env)
+    elif case_env is None:
+        if hasattr(contextlib, 'nullcontext'):
+            case_env = lambda _: contextlib.nullcontext
+        else:
+            case_env = lambda _: contextlib.ExitStack
+    
+    def tester(case):
+        input_key = 'AWS Lambda input'
+        _rest_prep_case(case, input_key)
+        
+        handler = handler_mapper.map(case['method'], case['resource'])
+        if hasattr(handler, 'resource'):
+            case[input_key]['resource'] = handler.resource
+        with case_env(case):
+            handler_result = handler(case[input_key], context)
+        
+        # TODO: test handler_result['statusCode'] against case['response status']
+        # TODO: test handler_result['mutliValueHeaders'] and/or handler_result['headers'] against case['response headers']
+        _rest_test_response_body(handler_result, case['response body'])
+    
+    return tester
+
+def _rest_prep_case(case: dict, aws_lambda_input_key: Any) -> None:
+    url = urlparse(case['url'])
+    _, stage, path = url.path.split('/', 2)
+    aws_event = dict(
+        requestContext=dict(
+            stage=stage,
+        ),
+        path='/' + path,
+        httpMethod=(case['method'] or 'get').lower(),
+        headers={},
+        multiValueHeaders={},
+        isBase64Encoded=False,
+    )
+    if 'stageVariables' in case:
+        aws_event['stageVariables'] = case['stageVariables']
+    # TODO: 'resource' in case?
+    if 'identity' in case:
+        aws_event['requestContext']['identity'] = case['identity']
+    if 'request headers' in case:
+        headers = case['request headers']
+        if hasattr(headers, 'items') and callable(headers.items):
+            headers = headers.items()
+        for name, value in headers:
+            aws_event['headers'][name] = value
+            aws_event['multiValueHeaders'].setdefault(name, []).append(value)
+    for name, value in parse_qsl(url.query):
+        aws_event['queryStringParameters'][name] = value
+        aws_event['multiValueQueryStringParameters'].setdefault(name, []).append(value)
+    if 'request body' in case:
+        _build_aws_event_body(case['request body'], aws_event)
+    
+    case[aws_lambda_input_key] = aws_event
+
+def _build_aws_event_body(request_body: OneOf[str, bytes, list, dict], aws_event) -> None:
+    if isinstance(request_body, str):
+        aws_event['body'] = case_request_body
+    elif isinstance(request_body, bytes):
+        aws_event.update(body=b64encode(request_body), isBase64Encoded=True)
+    else:
+        aws_event['body'] = json.dumps(request_body)
+        content_type = 'application/json'
+        aws_event['headers']['Content-Type'] = content_type
+        aws_event['multiValueHeaders']['Content-Type'] = [content_type]
+
+def _rest_test_response_body(handler_result: dict, expected: OneOf[str, bytes, list, dict]) -> None:
+    try:
+        assert isinstance(handler_result, dict), "handler result MUST be a dict"
+        assert 'body' in handler_result, "handler result MUST have a 'body'"
+        
+        if isinstance(expected, str):
+            assert handler_result['body'] == expected
+        elif isinstance(expected, bytes):
+            assert handler_result.get('isBase64Encoded', False), (
+                "handler result was not Base64 encoded (isBase64Encoded=False) when expected body is binary data"
+            )
+            assert b64decode(handler_result['body']) == expected
+        else:
+            assert json.loads(handler_result['body']) == expected
+    except AssertionError as e:
+        raise UnexpectedResponse(expected) from e
+
+"""
+def around_interface_case(case: dict):
+    # TODO: Set up data fixtures, service stubs, etc.
+    
+    yield
+    
+    # TODO: Tear down data fixtures, etc.
+
+def test_entrypoints():
+    case_provider = intercom_test.InterfaceCaseProvider(...)
+    service = intercom_test.aws_api.ServerlessHandlerMapper('../service')
+    for runner in case_provider.case_runners(service.case_tester('rest', case_env=around_interface_case)):
+        yield (runner,)
+"""

--- a/lib/intercom_test/aws_http.py
+++ b/lib/intercom_test/aws_http.py
@@ -2,30 +2,75 @@
 
 from abc import ABC, abstractmethod
 from base64 import b64encode, b64decode
+from collections import Counter
+from collections.abc import Mapping
 import contextlib
+import importlib
 import inspect
 import json
 from pathlib import Path
+import re
 import subprocess as subp
-from typing import Any, Callable, Optional, Union as OneOf
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union as OneOf
 from urllib.parse import urlparse, parse_qsl
+from intercom_test.utils import attributed_error, optional_key
 
 AwsLambdaHandler = Callable[[dict, dict], dict]
+ApiAdapter = Callable
 
-class NoRouteError(Exception):
-    """Raised to indicate no route matched the given method and path"""
-    def __init__(self, method: str, path: str):
-        super().__init__(f"{method.upper()} {path}")
-        self.method = method.upper()
-        self.path = path
+@attributed_error
+class NoRoute(Exception):
+    """Raised when no route matched the given method and path"""
+    
+    ATTRIBUTES = 'method path'
+    
+    def __str__(self, ):
+        return f"{self.method} {self.path}"
+
+@attributed_error
+class InvalidPathTemplate(Exception):
+    """Raised when an invalid routing path template"""
+    
+    ATTRIBUTES = 'path_template error_index'
+    
+    def __str__(self, ):
+        return f"invalid template syntax at charater index {self.error_index} of {self.path_template!r}"
+
+@attributed_error
+class UnexpectedResponseBody(AssertionError):
+    """Raised when the expected HTTP response was not generated"""
+    
+    ATTRIBUTES = 'actual expected'
+    
+    def __str__(self):
+        actual = self._format_body(self.actual)
+        expected = self._format_body(self.expected)
+        
+        return f"\n    ----- ACTUAL -----\n{actual}\n\n    ----- EXPECTED -----\n{expected}"
+    
+    @classmethod
+    def _format_body(cls, body, indent=4):
+        if isinstance(body, str):
+            body = json.dumps(expected)
+        elif isinstance(body, bytes):
+            content = ' '.join("%02x" % b for b in body)
+            if len(content) > 100:
+                content = content[:97] + '...'
+            body = f"<(binary) {content}>"
+        else:
+            body = json.dumps(body, indent=4)
+        
+        return ('\n' + body).replace('\n', '\n' + (indent * ' '))
 
 class HandlerMapper(ABC):
     """Abstract base class for classes that can map HTTP requests to handlers"""
     @abstractmethod
     def map(self, method: str, path: str) -> AwsLambdaHandler:
+        """Given an HTTP method and request path, return a handler function"""
         raise Exception("pure abstract method called")
 
 class FunctionalHandlerMapper(HandlerMapper):
+    """Adapter class to convert a mapper function to a :class:`HandlerMapper`"""
     def __init__(self, mapper: Callable[[str, str], AwsLambdaHandler]):
         super().__init__()
         self._mapper = mapper
@@ -34,35 +79,246 @@ class FunctionalHandlerMapper(HandlerMapper):
         return self._mapper(method, path)
 
 class ServerlessHandlerMapper(HandlerMapper):
-    PROJECT_FILE = 'serverless.yml'
+    """A :class:`HandlerMapper` drawing information from a Serverless project config
     
-    def __init__(self, project_dir):
+    The typical usage of this class is with :class:`~intercom_test.framework.InterfaceCaseProvider`,
+    as::
+    
+        import intercom_test.aws_http
+        
+        def around_interface_case(case: dict):
+            # Some kind of setup, possibly using *case*
+            try:
+                yield
+            finally:
+                # The corresponding teardown
+        
+        def test_interface_entrypoints():
+            case_provider = intercom_test.InterfaceCaseProvider(<args>)
+            service = intercom_test.aws_http.ServerlessHandlerMapper(<path-to-serverless-project>)
+            for test_runner in case_provider.case_runners(
+                service.case_tester(case_env=around_interface_case)
+            ):
+                yield (test_runner,)
+    """
+    
+    config_file = 'serverless.yml'
+    
+    def __init__(self, project_dir: OneOf[str, Path]):
+        """Construct an instance
+        
+        :param project_dir: root directory of the Serverless project
+        """
         super().__init__()
         self._project_dir = Path(project_dir)
     
+    @property
+    def project_dir(self) -> Path:
+        """Directory of the project"""
+        return self._project_dir
+    
     def map(self, method: str, path: str) -> AwsLambdaHandler:
+        """Using routing defined in the Serverless config to map a handler"""
         if not hasattr(self, '_routing'):
             self._build_routing()
         
-        for pred, handler in self._routing:
-            if pred(method, path):
-                return handler
+        for path_param_parser, handler in self._routing:
+            path_params = path_param_parser(method, path)
+            if path_params is not None:
+                # Integrate path_params into the event dict passed to handler under the key "pathParameters"
+                return lambda event, context: handler(
+                    dict(event, pathParameters=path_params),
+                    context
+                )
         
         raise NoRoute(method, path)
     
-    def case_tester(self, api_style: OneOf[str, ApiAdapter], **kwargs):
-        if isinstance(api_style, str):
-            api_style = globals()[f"ala_{api_style}_api"]
+    def case_tester(self, api_style: Optional[ApiAdapter] = None, **kwargs) -> Callable[[dict], None]:
+        """Convenience method for applying the HTTP API event adapter/testing logic
+        
+        The result of this method is intended to be passed to
+        :meth:`intercom_test.framework.InterfaceCaseProvider.case_runners`.
+        """
+        if api_style is None:
+            api_style = ala_http_api
         
         return api_style(self, **kwargs)
     
-    def _build_routing(self, ):
+    def _build_routing(self, ) -> None:
         """Call 'serverless print' and pull out resource-to-handler routing"""
         
-        raise Exception("not implemented")
+        serverless = self._get_rendered_serverless_config()
+        
+        routing = []
+        for fn_info in serverless['functions'].values():
+            routing.extend(_serverless_function_routes(fn_info))
+        # Sort routes (literals have precedence over params)
+        routing.sort(key=_routing_entry_sort_key)
+        self._routing = routing
+    
+    def _get_rendered_serverless_config(self, ) -> dict:
+        # This method invokes the "serverless" program; it can be overridden for testing
+        return json.loads(subp.check_output(
+            ['serverless', 'print', '--format', 'json', '--config', self.config_file],
+            cwd=self._project_dir,
+        ))
 
-def ala_rest_api(handler_mapper: HandlerMapper, context: Optional[dict] = None, case_env=None) -> Callabe[[dict], None]:
-    """Build a case tester from a :class:`HandlerMapper`
+def _serverless_function_routes(fn_info: dict):
+    # Generate (request_matcher, handler) pairs for a value in the 'functions'
+    # dict from a Serverless config
+    module_name, fn_name = fn_info['handler'].rsplit('.', 1)
+    module_name = module_name.replace('/', '.')
+    module = importlib.import_module(module_name)
+    
+    for method, path_template in _httpApi_routes(fn_info['events']):
+        handler = getattr(module, fn_name)
+        handler = LambdaHandlerProxy(handler, resource=path_template)
+        yield (OpenAPIPathMatcher(method, path_template), handler)
+
+def _httpApi_routes(event_list: list):
+    # Generate (method, path_template) pairs from an 'events' entry under an
+    # entry of 'functions' in a Serverless config
+    for entry in event_list:
+        http_event = entry.get('httpApi')
+        if http_event is None:
+            continue
+        
+        if http_event == '*':
+            http_event = 'ANY /{proxy+}'
+        elif isinstance(http_event, dict) and http_event['method'] == '*':
+            http_event = dict(http_event, method='ANY')
+        
+        if isinstance(http_event, str):
+            yield http_event.split(maxsplit=1)
+        else:
+            yield (http_event['method'], http_event['path'])
+
+# TODO: This implementation of OpenAPIPathMatcher restricts parameters to
+# segments between slashes, which is more restrictive than the OpenAPI
+# specification; fix to remove this restriction
+PATH_TEMPLATE_SEGMENT = re.compile(r'/(?:(?:\{(?P<param>[^}]+)\})|(?P<lit>(?!\{)[^/]+))')
+PATH_SEGMENT = re.compile(r'/(?P<value>[^/]+)')
+class OpenAPIPathMatcher:
+    """A callable class to match and extract parameters from a URL path
+    
+    Instances accept a call with an HTTP method and a URL path-part and return
+    either ``None`` for no match, or a :class:`dict` mapping path parameter
+    names to their extracted values.  A returned mapping may be empty, so be
+    sure to use the ``is not None`` test instead of implicit conversion to
+    :class:`bool`.
+    """
+    
+    class Param(str):
+        """String giving the name of a path parameter"""
+
+        @property
+        def isvartail(self):
+            return self.endswith('+')
+
+    def __init__(self, route_method: str, route_path: str):
+        """Construct an instance
+        
+        :param route_method:
+            HTTP method or ``'*'`` for a wildcard
+        :param route_path:
+            path part of a URL to match, which may include OpenAPI template
+            parameters
+        
+        NOTE: With the current implementation, template parameters are only
+        allowed to match a full segment of the path (between slashes or from
+        a slash to the end of the path).
+        """
+        super().__init__()
+        self.method = route_method
+
+        self.path = route_path
+        self.path_segments = []
+        match_start = 0
+        while match_start < len(route_path):
+            seg = PATH_TEMPLATE_SEGMENT.match(route_path, match_start)
+            if seg is None:
+                raise InvalidPathTemplate(route_path, match_start)
+            if seg.group('param'):
+                param = self.Param(seg.group('param'))
+                if param.isvartail and seg.span()[1] < len(route_path):
+                    raise InvalidPathTemplate(route_path, seg.span()[1])
+                self.path_segments.append(param)
+            elif seg.group('lit'):
+                self.path_segments.append(seg.group('lit'))
+            else:
+                raise Exception(f"unknown path segment type for {seg.group()!r}")
+            match_start = seg.span()[1]
+
+    def __call__(self, request_method: str, request_path: str) -> Optional[dict]:
+        """See class documentation"""
+        if self.method != '*' and request_method != self.method:
+            return None
+
+        template_segments = list(self.path_segments)
+        match_start = 0
+        captured_params = {}
+        for template_seg in template_segments:
+            matching_param = isinstance(template_seg, self.Param)
+
+            if matching_param and template_seg.isvartail:
+                captured_params[template_seg[:-1]] = request_path[match_start + 1:]
+                match_start = len(request_path)
+                continue
+
+            request_seg = PATH_SEGMENT.match(request_path, match_start)
+            if request_seg is None:
+                return None
+            if matching_param:
+                captured_params[template_seg[:]] = request_seg.group('value')
+            elif request_seg.group('value') != template_seg:
+                return None
+
+            match_start = request_seg.span()[1]
+
+        if match_start < len(request_path):
+            return None
+
+        return captured_params
+
+    def __repr__(self, ):
+        return f"<{type(self).__name__} method={self.method!r} path={self.path!r}>"
+
+
+def _routing_entry_sort_key(route_entry: Tuple[OpenAPIPathMatcher, AwsLambdaHandler]) -> Tuple[Tuple[int, str], ...]:
+    path_segs = route_entry[0].path_segments
+    
+    def seg_sort_key(seg):
+        is_param = isinstance(seg, OpenAPIPathMatcher.Param)
+        return (
+            1 if is_param else 0,
+            '' if is_param else seg,
+        )
+    
+    return tuple(seg_sort_key(seg) for seg in path_segs)
+
+class LambdaHandlerProxy:
+    """Wrapper for a Lambda handler allowing decoration with additional attributes
+    
+    A single handler function may be bound to multiple integrations, and the
+    information relevant to that binding may be useful or needed for constructing
+    the event to send to the handler.
+    """
+    def __init__(self, handler: AwsLambdaHandler, *, resource: Optional[str] = None):
+        super().__init__()
+        self.handler = handler
+        self.resource = resource
+    
+    def __call__(self, *args, **kwargs):
+        return self.handler(*args, **kwargs)
+    
+    def __repr__(self, ):
+        parts = [type(self).__name__, f"for {self.handler.__module__}.{self.handler.__qualname__}"]
+        if self.resource:
+            parts.append(f"(mapped from {self.resource!r})")
+        return f"<{' '.join(parts)}>"
+
+def ala_rest_api(handler_mapper: HandlerMapper, context: Optional[dict] = None, case_env=None) -> Callable[[dict], None]:
+    """Build a case tester from a :class:`HandlerMapper` for a REST API
     
     :param handler_mapper: maps from method and path to an AWS Lambda handler function
     :param context: optional context information to pass to the identified handler
@@ -74,54 +330,108 @@ def ala_rest_api(handler_mapper: HandlerMapper, context: Optional[dict] = None, 
     :func:`contextlib.contextmanager`.  In either case, the context manager
     constructor is invoked with the test case data :class:`dict` around
     invocation of the handler callable.
+    
+    The following keys are treated specially in the test case data accepted by
+    the returned callable:
+    
+    ``'method'``
+        (:class:`str`, **required**) The HTTP method
+    
+    ``'url'``
+        (:class:`str`, **required**) The path part of the URL
+    
+    ``'stageVariables'``
+        (:class:`dict`) Mapping of stage variables to their values
+    
+    ``'identity'``
+        (:class:`dict`) Client identity information used to populate
+        ``$.requestContext.identity``
+    
+    ``'request headers'``
+        (:class:`dict` or list of 2-item lists) HTTP headers for request
+    
+    ``'request body'``
+        A :class:`str`, :class:`bytes`, or JSONic data type giving the body
+        of the request to test; JSONic data is rendered to JSON for submission
+        and implies a ``Content-Type`` header of ``'application/json'``
+    
+    ``'response status'``
+        (:class:`int`) The HTTP response status code number expected, defaulting
+        to 200
+    
+    ``'response headers'``
+        (:class:`dict` or list of 2-item lists) HTTP headers required in the
+        response; if a header is listed here and is returned as a multi-value
+        header (in ``'multiValueHeaders'``), the *set* of values in the
+        response is expected to match the *set* of values listed here in the
+        test case
+    
+    ``'response body'``
+        (**required**) A :class:`str`, :class:`bytes`, or JSONic data type
+        giving the expected body of the response; JSONic data is compared
+        against the response by parsing the body of the response as JSON, then
+        comparing to the data given here in the test case
     """
     if context is None:
         context = {}
     
+    # TODO: case_env = _case_env_contextmanager(case_env)
     if inspect.isgeneratorfunction(case_env):
         case_env = contextlib.contextmanager(case_env)
     elif case_env is None:
-        if hasattr(contextlib, 'nullcontext'):
-            case_env = lambda _: contextlib.nullcontext
-        else:
-            case_env = lambda _: contextlib.ExitStack
+        case_env = lambda _: _nullcontext()
     
     def tester(case):
         input_key = 'AWS Lambda input'
         _rest_prep_case(case, input_key)
         
-        handler = handler_mapper.map(case['method'], case['resource'])
+        handler = handler_mapper.map(
+            case[input_key]['httpMethod'],
+            case[input_key]['path']
+        )
         if hasattr(handler, 'resource'):
             case[input_key]['resource'] = handler.resource
         with case_env(case):
             handler_result = handler(case[input_key], context)
         
-        # TODO: test handler_result['statusCode'] against case['response status']
-        # TODO: test handler_result['mutliValueHeaders'] and/or handler_result['headers'] against case['response headers']
-        _rest_test_response_body(handler_result, case['response body'])
+        _confirm_response_code(handler_result['statusCode'], case.get('response status', 200))
+        _confirm_response_headers(
+            handler_result['headers'],
+            handler_result['multiValueHeaders'],
+            case['response headers']
+        )
+        _confirm_response_body(handler_result, case['response body'])
     
     return tester
 
 def _rest_prep_case(case: dict, aws_lambda_input_key: Any) -> None:
+    """Build the AWS Lambda input data and inject into the test case data
+    
+    :param case: test case data
+    :param aws_lambda_input_key: key in *case* to set with AWS Lambda input data
+    
+    The event :class:`dict` built is for a REST API Lambda integration.
+    """
     url = urlparse(case['url'])
     _, stage, path = url.path.split('/', 2)
     aws_event = dict(
         requestContext=dict(
             stage=stage,
         ),
+        stageVariables={},
         path='/' + path,
-        httpMethod=(case['method'] or 'get').lower(),
+        httpMethod=case.get('method', 'get').lower(),
+        queryStringParameters={},
+        multiValueQueryStringParameters={},
         headers={},
         multiValueHeaders={},
         isBase64Encoded=False,
     )
-    if 'stageVariables' in case:
-        aws_event['stageVariables'] = case['stageVariables']
-    # TODO: 'resource' in case?
-    if 'identity' in case:
-        aws_event['requestContext']['identity'] = case['identity']
-    if 'request headers' in case:
-        headers = case['request headers']
+    for vars in optional_key(case, 'stageVariables'):
+        aws_event['stageVariables'] = vars
+    for identity in optional_key(case, 'identity'):
+        aws_event['requestContext']['identity'] = identity
+    for headers in optional_key(case, 'request headers'):
         if hasattr(headers, 'items') and callable(headers.items):
             headers = headers.items()
         for name, value in headers:
@@ -130,12 +440,188 @@ def _rest_prep_case(case: dict, aws_lambda_input_key: Any) -> None:
     for name, value in parse_qsl(url.query):
         aws_event['queryStringParameters'][name] = value
         aws_event['multiValueQueryStringParameters'].setdefault(name, []).append(value)
-    if 'request body' in case:
-        _build_aws_event_body(case['request body'], aws_event)
+    for body in optional_key(case, 'request body'):
+        _build_aws_event_body(body, aws_event)
     
     case[aws_lambda_input_key] = aws_event
 
-def _build_aws_event_body(request_body: OneOf[str, bytes, list, dict], aws_event) -> None:
+def ala_http_api(handler_mapper: HandlerMapper, context: Optional[dict] = None, case_env=None) -> Callable[[dict], None]:
+    """Build a case tester from a :class:`HandlerMapper` for an HTTP API
+    
+    :param handler_mapper: maps from method and path to an AWS Lambda handler function
+    :param context: optional context information to pass to the identified handler
+    :param case_env: context function for setup/teardown with access to the test case
+    
+    The *case_env* (if given) must be either a generator function that yields
+    a single time or a callable returning a *context manager*.  If a generator
+    function is given, it is converted to a context manager constructor with
+    :func:`contextlib.contextmanager`.  In either case, the context manager
+    constructor is invoked with the test case data :class:`dict` around
+    invocation of the handler callable.
+    
+    The following keys are treated specially in the test case data accepted by
+    the returned callable (where those required are labeled as such):
+    
+    ``'method'``
+        (:class:`str`, **required**) The HTTP method
+    
+    ``'url'``
+        (:class:`str`, **required**) The path part of the URL
+    
+    ``'stageVariables'``
+        (:class:`dict`) Mapping of stage variables to their values
+    
+    ``'client certificate'``
+        (:class:`dict`) The field of the client certificate provided for the
+        test, to populate ``$.requestContext.authentication.clientCert``
+    
+    ``'request authorization'``
+        (:class:`dict`) Used to populate ``$.requestContext.authorizer``
+    
+    ``'request headers'``
+        (:class:`dict` or list of 2-item lists) HTTP headers for request
+    
+    ``'request body'``
+        A :class:`str`, :class:`bytes`, or JSONic data type giving the body
+        of the request to test; JSONic data is rendered to JSON for submission
+        and implies a ``Content-Type`` header of ``'application/json'``
+    
+    ``'response status'``
+        (:class:`int`) The HTTP response status code number expected, defaulting
+        to 200
+    
+    ``'response headers'``
+        (:class:`dict` or list of 2-item lists) HTTP headers required in the
+        response; if a header is listed here and is returned as a multi-value
+        header (in ``'multiValueHeaders'``), the *set* of values in the
+        response is expected to match the *set* of values listed here in the
+        test case
+    
+    ``'response body'``
+        (**required**) A :class:`str`, :class:`bytes`, or JSONic data type
+        giving the expected body of the response; JSONic data is compared
+        against the response by parsing the body of the response as JSON, then
+        comparing to the data given here in the test case
+    """
+    if context is None:
+        context = {}
+    
+    # TODO: case_env = _case_env_contextmanager(case_env)
+    if inspect.isgeneratorfunction(case_env):
+        case_env = contextlib.contextmanager(case_env)
+    elif case_env is None:
+        case_env = lambda _: _nullcontext()
+    
+    def tester(case):
+        input_key = 'AWS Lambda input'
+        _http_prep_case(case, input_key)
+        
+        handler = handler_mapper.map(
+            case[input_key]['requestContext']['http']['method'],
+            case[input_key]['rawPath']
+        )
+        with case_env(case):
+            handler_result = handler(case[input_key], context)
+        
+        handler_result = _http_conformed_result(handler_result)
+        
+        _confirm_response_code(
+            handler_result['statusCode'],
+            case.get('response status', 200)
+        )
+        for expected_headers in optional_key(case, 'response headers'):
+            _confirm_response_headers(
+                handler_result.get('headers', {}),
+                handler_result.get('multiValueHeaders', {}),
+                expected_headers
+            )
+        _confirm_response_body(handler_result, case['response body'])
+    
+    return tester
+
+def _http_prep_case(case: dict, aws_lambda_input_key: Any) -> None:
+    """Build the AWS Lambda input data and inject into the test case data
+    
+    :param case: test case data
+    :param aws_lambda_input_key: key in *case* to set with AWS Lambda input data
+    
+    The event :class:`dict` built is for a HTTP API Lambda proxy integration.
+    """
+    url = urlparse(case['url'])
+    aws_event = dict(
+        requestContext=dict(
+            http=dict(
+                method=case.get('method', 'get').lower(),
+                path=url.path,
+                protocol='HTTP/1.1',
+            ),
+            authentication={},
+            authorizer={},
+        ),
+        rawPath=url.path,
+        rawQueryString=url.query,
+        headers={},
+        isBase64Encoded=False,
+        stageVariables={},
+        queryStringParameters={},
+    )
+    for vars in optional_key(case, 'stageVariables'):
+        aws_event['stageVariables'] = vars
+    for certificate in optional_key(case, 'client certificate'):
+        aws_event['requestContext']['authentication']['clientCert'] = certificate
+    for authorization in optional_key(case, 'request authorization'):
+        aws_event['requestContext']['authorizer'] = authorization
+    for headers in optional_key(case, 'request headers'):
+        if hasattr(headers, 'items') and callable(headers.items):
+            headers = headers.items()
+        event_headers = aws_event['headers']
+        for name, value in headers:
+            # TODO: Special case for cookies
+            if name in event_headers:
+                event_headers[name] += ',' + value
+            else:
+                event_headers[name] = value
+    event_qsparams = aws_event['queryStringParameters']
+    for name, value in parse_qsl(url.query):
+        if name in event_qsparams:
+            event_qsparams[name] += ',' + value
+        else:
+            event_qsparams[name] = value
+    for body in optional_key(case, 'request body'):
+        _build_aws_event_body(body, aws_event)
+    
+    case[aws_lambda_input_key] = aws_event
+
+def _http_conformed_result(result: OneOf[Mapping, str, Iterable]) -> dict:
+    """Apply HTTP API v2.0 Lambda function output rules"""
+    
+    if isinstance(result, Mapping) and 'statusCode' in result:
+        return result if isinstance(result, dict) else dict(result)
+    
+    if not isinstance(result, str):
+        result = json.dumps(result)
+    
+    return dict(
+        isBase64Encoded=False,
+        statusCode=200,
+        body=result,
+        headers={
+            "Content-Type": "application/json",
+        },
+    )
+
+def _build_aws_event_body(request_body: OneOf[str, bytes, list, dict], aws_event: dict) -> None:
+    """Modify the AWS Lambda input event based on request body
+    
+    The type of *request_body* determines how the body is represented in
+    *aws_event*.  The ``'body'`` and ``'isBase64Encoded'`` keys of *aws_event*
+    and the ``'Content-Type'`` subkey of ``aws_event['headers']`` and
+    ``aws_event['multiValueHeaders']`` may be assigned, depending on the
+    data in *request_body*.
+    
+    When this function is called, *aws_event* is expected to *not* have any
+    request-body-related information set.
+    """
     if isinstance(request_body, str):
         aws_event['body'] = case_request_body
     elif isinstance(request_body, bytes):
@@ -144,36 +630,69 @@ def _build_aws_event_body(request_body: OneOf[str, bytes, list, dict], aws_event
         aws_event['body'] = json.dumps(request_body)
         content_type = 'application/json'
         aws_event['headers']['Content-Type'] = content_type
-        aws_event['multiValueHeaders']['Content-Type'] = [content_type]
+        if 'multiValueHeaders' in aws_event:
+            aws_event['multiValueHeaders']['Content-Type'] = [content_type]
 
-def _rest_test_response_body(handler_result: dict, expected: OneOf[str, bytes, list, dict]) -> None:
+def _confirm_response_code(actual: int, expected: int) -> None:
+    assert actual == expected, (
+        f"expected HTTP response code {expected}, but got {actual}"
+    )
+
+def _confirm_response_headers(actual_headers: Dict[str, str], actual_mv_headers: Dict[str, Iterable[str]], expected_headers: OneOf[Dict[str, str], Iterable[Tuple[str, str]]]):
+    if hasattr(expected_headers, 'items'):
+        expected_headers = expected_headers.items()
+    
+    errors = []
+    mv_header_counts = Counter()
+    for name, value in expected_headers:
+        if name in actual_headers and actual_headers['name'] == value:
+            pass
+        elif name in actual_mv_headers and value in actual_mv_headers['name']:
+            mv_header_counts[name] += 1
+        else:
+            errors.append(
+                f"header {name!r} not found with value {value!r}"
+            )
+    
+    for name, expected_count in mv_header_counts.items():
+        if name not in actual_headers:
+            pass
+        elif actual_headers[name] not in actual_mv_headers[name]:
+            expected_count -= 1
+        
+        actual_count = len(actual_mv_headers[name])
+        if actual_count != expected_count:
+            errors.append(
+                f"multi-valued header {name!r} appeared with {actual_count} value(s), but expected {expected_count}"
+            )
+    
+    if len(errors) == 1:
+        raise AssertionError(errors[0])
+    if errors:
+        raise AssertionError('\n    * '.join(['multiple errors'] + errors))
+
+def _confirm_response_body(handler_result: dict, expected: OneOf[str, bytes, list, dict]) -> None:
+    actual = None
     try:
         assert isinstance(handler_result, dict), "handler result MUST be a dict"
         assert 'body' in handler_result, "handler result MUST have a 'body'"
         
         if isinstance(expected, str):
+            actual = handler_result['body']
             assert handler_result['body'] == expected
         elif isinstance(expected, bytes):
             assert handler_result.get('isBase64Encoded', False), (
                 "handler result was not Base64 encoded (isBase64Encoded=False) when expected body is binary data"
             )
+            actual = b64decode(handler_result['body'])
             assert b64decode(handler_result['body']) == expected
         else:
+            actual = json.loads(handler_result['body'])
             assert json.loads(handler_result['body']) == expected
     except AssertionError as e:
-        raise UnexpectedResponse(expected) from e
+        if actual is None:
+            raise e
+        raise UnexpectedResponseBody(actual, expected).with_traceback(e.__traceback__) from e
 
-"""
-def around_interface_case(case: dict):
-    # TODO: Set up data fixtures, service stubs, etc.
-    
-    yield
-    
-    # TODO: Tear down data fixtures, etc.
-
-def test_entrypoints():
-    case_provider = intercom_test.InterfaceCaseProvider(...)
-    service = intercom_test.aws_api.ServerlessHandlerMapper('../service')
-    for runner in case_provider.case_runners(service.case_tester('rest', case_env=around_interface_case)):
-        yield (runner,)
-"""
+# Fallback for Python < 3.7
+_nullcontext = getattr(contextlib, 'nullcontext', contextlib.ExitStack)

--- a/lib/intercom_test/http_best_matches.py
+++ b/lib/intercom_test/http_best_matches.py
@@ -1,0 +1,633 @@
+"""Module for finding nearest imperfect match for HTTP request"""
+
+from abc import ABC, abstractmethod
+from base64 import b64encode
+from collections import namedtuple
+from collections.abc import Mapping, Sequence
+from difflib import SequenceMatcher
+from enum import IntEnum
+from heapq import heappush, heappop
+import itertools
+import Levenshtein
+import math
+from operator import itemgetter
+import time
+from typing import Iterable, Tuple, Sequence as SequenceType
+from urllib.parse import urlparse, parse_qsl
+
+class Database:
+    def __init__(self, cases: Iterable[dict]):
+        super().__init__()
+        
+        if not isinstance(cases, Sequence):
+            cases = list(cases)
+        
+        self._reqlines = _group_dict(cases, _reqline)
+        self._urls = _group_dict(cases, _request_url)
+        self._paths = _group_dict(cases, _request_url_path)
+        
+    def best_matches(self, request: dict, *, timeout: float = 0.3) -> dict:
+        """Given HTTP request parameters, find the best known match"""
+        
+        return _Reporter(self, request, deadline=time.time() + timeout).report()
+
+class _Reporter:
+    def __init__(self, database, request, *, deadline=math.inf):
+        super().__init__()
+        self.database = database
+        self.request = request
+        self.deadline = deadline
+    
+    @property
+    def request_body(self):
+        return self.request['request body']
+    
+    def report(self, ):
+        db = self.database
+        request = self.request
+        if _reqline(request) in db._reqlines:
+            return self._report_closest_request_bodies()
+        
+        if _request_url(request) in db._urls:
+            return self._report_available_methods()
+        
+        request_path = _request_url_path(request)
+        if request_path in db._paths:
+            return self._report_closest_query_params()
+        
+        def dist_from_request_path(url):
+            return Levenshtein.distance(url, request_path)
+        
+        # TODO: Use a min-priority queue on dist_from_request_url and add items
+        # to it until the deadline (or all items added), then pop the top 5
+        closest_paths = sorted(db._paths, key=dist_from_request_path)[:5]
+        
+        return AvailablePathsReport(list(
+            (path, db._paths[path])
+            for path in closest_paths
+        ))
+    
+    def _report_closest_request_bodies(self, ):
+        # Report items in the database that have the most similar request bodies
+        request_body = self.request_body
+        reqbody_is_jsonic = _is_jsonic_body(request_body)
+        reqbody_type = type(request_body)
+        available_cases = list(
+            case
+            for case in self.database._reqlines[_reqline(self.request)]
+            if type(case['request body']) == reqbody_type
+        )
+        
+        if reqbody_is_jsonic:
+            jcomp = JsonComparer(self.request_body)
+            near_reqbodies_heap = []
+            for i, case in enumerate(available_cases):
+                if time.time() >= self.deadline:
+                    break
+                
+                diff = jcomp.diff(case['request body'])
+                
+                heappush(near_reqbodies_heap, (
+                    diff.edit_distance(),
+                    i,
+                    diff,
+                    case
+                ))
+            
+            closest_reqbody_entries = list(
+                heappop(near_reqbodies_heap)[2:]
+                for _ in range(min(5, len(near_reqbodies_heap)))
+            )
+            
+            return AvailableJsonRequestBodiesReport(closest_reqbody_entries)
+        else:
+            # Look for lowest Levenshtein distance between request_body and case['request body']
+            def distance_from_request_body(case):
+                return Levenshtein.distance(request_body, case['request body'])
+            
+            # TODO: Use a min-priority queue on distance_from_request_body and
+            # add items to it until the deadline (or all items added), then pop
+            # the top 5
+            closest_reqbodies = sorted(
+                available_cases,
+                key=distance_from_request_body
+            )[:5]
+            
+            return AvailableScalarRequestBodiesReport(closest_reqbodies)
+    
+    def _report_available_methods(self, ):
+        # Report the HTTP methods that are valid for this URL (path and query-string)
+        return AvailableHttpMethodsReport(
+            _http_method(case)
+            for case in self.database._urls[_request_url(self.request)]
+        )
+    
+    def _report_closest_query_params(self, ):
+        # Report the query parameter deltas that would produce a known URL with
+        # the same path part
+        request_path, request_qsparams = _request_url(self.request)
+        qscomp = QStringComparer(request_qsparams)
+        near_urls_heap = []
+        for i, case in enumerate(self.database._paths[request_path]):
+            if time.time() >= self.deadline:
+                break
+            
+            diff = qscomp.diff(_request_url(case)[1])
+            
+            heappush(near_urls_heap, (
+                diff.edits,
+                i,
+                diff,
+                case
+            ))
+        
+        closest_url_entries = list(
+            heappop(near_urls_heap)[2:]
+            for _ in range(min(5, len(near_urls_heap)))
+        )
+        
+        return AvailableQueryStringParamsetsReport(closest_url_entries)
+
+class Report(ABC):
+    @abstractmethod
+    def as_jsonic_data(self, ):
+        """Convert this report to JSON data"""
+
+class AvailablePathsReport(Report):
+    def __init__(self, test_case_groups):
+        super().__init__()
+        self.test_case_groups = test_case_groups
+    
+    def as_jsonic_data(self, ):
+        return {
+            'closest URL paths': list(
+                (path, list(
+                    case.get('description')
+                    for case in cases
+                    if 'description' in case
+                ))
+                for path, cases in self.test_case_groups
+            )
+        }
+
+class AvailableJsonRequestBodiesReport(Report):
+    def __init__(self, diff_case_pairs):
+        super().__init__()
+        self.diff_case_pairs = diff_case_pairs
+    
+    def as_jsonic_data(self, ):
+        return {
+            'minimal JSON request body deltas': list(
+                {
+                    'case description': case.get('description'),
+                    'diff': self._json_diff_json(diff),
+                }
+                for diff, case in self.diff_case_pairs
+            )
+        }
+    
+    @classmethod
+    def _json_diff_json(cls, json_diff: 'JsonComparer.Delta'):
+        if json_diff.structure_diffs:
+            return {'alter substructures': list(
+                cls._json_mod_json(mod)
+                for mod in json_diff.structure_diffs
+            )}
+        
+        if json_diff.structure_location_diffs:
+            return {'rearrange substructures': list(
+                cls._json_mod_json(mod)
+                for mod in json_diff.structure_location_diffs
+            )}
+        
+        if json_diff.scalar_diffs:
+            return {'alter scalar values': list(
+                cls._json_mod_json(mod)
+                for mod in json_diff.scalar_diffs
+            )}
+    
+    @classmethod
+    def _json_mod_json(cls, mod):
+        result = {}
+        for k in set(mod).intersection({'alt', 'del'}):
+            result[k] = mod[k]
+        if any(k in mod for k in ('alt', 'add')):
+            result.update(
+                (k, cls._json_struct_desc(v))
+                for k, v in mod.items()
+                if k in ('to', 'add')
+            )
+        if 'set' in mod:
+            result.update((k, mod[k]) for k in ('set', 'to'))
+        
+        return result
+    
+    @classmethod
+    def _json_struct_desc(cls, sig):
+        coll_type, element_type_info = sig
+        if coll_type is JsonType.list:
+            return list(jt.construct() for jt in element_type_info)
+        if coll_type is JsonType.dict:
+            return dict((name, jt.construct()) for name, jt in element_type_info)
+    
+
+class AvailableScalarRequestBodiesReport(Report):
+    def __init__(self, test_cases):
+        super().__init__()
+        self.test_cases = test_cases
+    
+    def as_jsonic_data(self, ):
+        return {'closest request bodies': list(
+            {
+                'case description': case.get('description'),
+                **self._body_json(case['request body']),
+            }
+            for case in self.test_cases
+        )}
+    
+    @classmethod
+    def _body_json(cls, body):
+        main_key = 'request body'
+        if isinstance(body, bytes):
+            return {
+                main_key: b64encode(body).decode('ASCII'),
+                'isBase64Encoded': True,
+            }
+        else:
+            return {main_key: body}
+    
+
+class AvailableHttpMethodsReport(Report):
+    def __init__(self, methods):
+        super().__init__()
+        self.methods = set(methods)
+    
+    def as_jsonic_data(self, ):
+        return {'available HTTP methods': list(self.methods)}
+    
+
+class AvailableQueryStringParamsetsReport(Report):
+    def __init__(self, deltas):
+        super().__init__()
+        self.deltas = deltas
+    
+    def as_jsonic_data(self, ):
+        return {
+            'minimal query string deltas': list(
+                {
+                    'case description': case.get('description'),
+                    'diff': self._qstring_diff_json(diff),
+                }
+                for diff, case in self.deltas
+            )
+        }
+    
+    def _qstring_diff_json(self, qsparam_diff: 'QStringComparer.Delta'):
+        return {
+            'params with differing value sequences': qsparam_diff.params,
+            'mods': qsparam_diff.mods,
+        }
+
+def _request_url_path(case):
+    return urlparse(case['url']).path
+
+def _request_url(case):
+    url = urlparse(case['url'])
+    qsparams = sorted(
+        parse_qsl(url.query),
+        # key=lambda i: (i[1][0], i[0])
+        key=itemgetter(0)
+    )
+    return (url.path, tuple(qsparams))
+
+def _http_method(case):
+    return case.get('method', 'get').lower()
+
+def _reqline(case):
+    return (_http_method(case), case['url'])
+
+def _group_dict(a: Iterable, key, *, value=lambda x: x) -> dict:
+    result = {}
+    for item in a:
+        result.setdefault(key(item), []).append(value(item))
+    return result
+
+class JsonWalker:
+    
+    def walk(self, json_data):
+        yield from self._walk_node(json_data, ())
+    
+    def _walk_node(self, node, key_path):
+        if isinstance(node, Mapping):
+            yield from self._visit_dict(node, key_path)
+        elif isinstance(node, (list, tuple)):
+            yield from self._visit_list(node, key_path)
+        else:
+            yield from self._visit_scalar(node, key_path)
+    
+    def _visit_scalar(self, value, key_path):
+        yield ((lookup_json_type(type(value)), value), value, key_path)
+    
+    def _visit_list(self, L, key_path):
+        yield ((JsonType.list, tuple(lookup_json_type(type(i)) for i in L)), L, key_path)
+        yield from (
+            event
+            for i, item in enumerate(L)
+            for event in self._walk_node(item, key_path + (i,))
+        )
+    
+    def _visit_dict(self, d, key_path):
+        yield ((JsonType.dict, frozenset((k, lookup_json_type(type(v))) for k, v in d.items())), d, key_path)
+        yield from (
+            event
+            for i, k in enumerate(sorted(d))
+            for event in self._walk_node(d[k], key_path + (k,))
+        )
+    
+class JsonMap:
+    def __init__(self, json_data):
+        super().__init__()
+        self._root = json_data
+        self._json_index = json_index = list(JsonWalker().walk(json_data))
+    
+    @property
+    def substruct_signatures(self):
+        """Indexes correspond with :meth:`.substruct_key_paths`"""
+        if not hasattr(self, '_substruct_signatures'):
+            self._index_substructures()
+        return self._substruct_signatures
+    
+    @property
+    def substruct_key_paths(self):
+        """Indexes correspond with :meth:`.substruct_signatures`"""
+        if not hasattr(self, '_substruct_key_paths'):
+            self._index_substructures()
+        return self._substruct_key_paths
+    
+    @property
+    def substruct_locations(self, ):
+        if not hasattr(self, '_substruct_locations'):
+            self._substruct_locations = tuple(
+                (item[2], item[0])
+                for item in self._json_index
+                if item[0][0].is_collection
+            )
+        return self._substruct_locations
+    
+    def items_from_signature(self, sig):
+        if not hasattr(self, '_items_by_signature'):
+            self._items_by_signature = _group_dict(
+                self._json_index,
+                key=itemgetter(0),
+                value=itemgetter(1),
+            )
+        return self._items_by_signature.get(sig, [])
+    
+    @property
+    def scalars(self):
+        """Indexes correspond with :meth:`.scalar_key_paths`"""
+        if not hasattr(self, '_scalars'):
+            self._scalars = tuple(
+                (item[2], item[1])
+                for item in self._json_index
+                if not item[0][0].is_collection
+            )
+        return self._scalars
+    
+    def _index_substructures(self, ):
+        type_sorted_substructures = sorted(
+            (
+                item for item in self._json_index
+                if item[0][0].is_collection
+            ),
+            key=itemgetter(0)
+        )
+        
+        self._substruct_signatures = tuple(
+            item[0] for item in type_sorted_substructures
+        )
+        self._substruct_key_paths = tuple(
+            item[2] for item in type_sorted_substructures
+        )
+
+class JsonComparer:
+    """Utility to compare one JSON document with several others"""
+    
+    CONGRUENT_DATA = 'congruent options'
+    
+    def __init__(self, ref):
+        super().__init__()
+        self.ref_map = JsonMap(ref)
+    
+    class Delta(tuple):
+        """Differences between two JSON documents
+        
+        This difference always consists of three parts, in decreasing order of
+        precedence:
+        
+        * Changes to which substructures are present,
+        * Changes to where substructures are located, and
+        * Changes to scalar values.
+        
+        Only one of these three will be non-empty.
+        
+        Use :meth:`.distance` to get a sortable distance measure for this
+        delta.
+        """
+        __slots__ = []
+        
+        def __new__(cls, struct, struct_loc, scalar):
+            return tuple.__new__(cls, (struct, struct_loc, scalar))
+        
+        @property
+        def structure_diffs(self):
+            return self[0]
+        
+        @property
+        def structure_location_diffs(self):
+            return self[1]
+        
+        @property
+        def scalar_diffs(self):
+            return self[2]
+        
+        def edit_distance(self, ):
+            return tuple(map(len, self))
+    
+    def diff(self, case) -> Delta:
+        """Diffs two JSON documents
+        
+        The difference evaluation proceeds in three steps, with each of the
+        later steps proceeding only if the earlier step produced no differences.
+        
+        The steps are:
+        
+        *   All substructures (lists and dicts, with correct subitem signatures)
+            are present.
+        *   All substructures are in the correct locations.
+        *   Each scalar value location holds the expected scalar value.
+        
+        To reflect this, the differences are returned as a tuple of three
+        :class:`.Sequence`s wrapped in a :class:`.JsonComparer.Delta`, only one
+        of which will contain any items:
+        
+        *   Changes to which substructures are present.
+        *   Changes to where substructures are located.
+        *   Changes to scalar values.
+        
+        """
+        ref_map = self.ref_map
+        case_map = JsonMap(case)
+        
+        # First, diff sorted substructures
+        diffs = tuple(self._substruct_signature_diffs(ref_map, case_map))
+        if diffs:
+            return self.Delta(diffs, (), ())
+        # Second, diff (key_path, substruct_sig) pairs
+        diffs = tuple(self._substruct_location_diffs(ref_map, case_map))
+        if diffs:
+            return self.Delta((), diffs, ())
+        # Finally, diff scalars in document order
+        diffs = tuple(self._scalar_diffs(ref_map, case_map))
+        return self.Delta((), (), diffs)
+    
+    def _substruct_signature_diffs(self, ref_map: JsonMap, case_map: JsonMap):
+        sm = SequenceMatcher(None, ref_map.substruct_signatures, case_map.substruct_signatures)
+        
+        for op_type, i1, i2, j1, j2 in sm.get_opcodes():
+            if op_type == 'equal':
+                continue
+            
+            current = (ref_map.substruct_key_paths[i] for i in range(i1, i2))
+            target = (case_map.substruct_signatures[j] for j in range(j1, j2))
+            
+            # Use weird range iterator to prevent pulling an extra item from current while zipping
+            for _, key_path, struct_sig in zip(_alt_range(i1, i2, j1, j2), current, target):
+                yield {'alt': key_path, 'to': struct_sig, self.CONGRUENT_DATA: case_map.items_from_signature(struct_sig)}
+            for key_path in current:
+                yield {'del': key_path}
+            for struct_sig in target:
+                yield {'add': struct_sig, self.CONGRUENT_DATA: case_map.items_from_signature(struct_sig)}
+    
+    def _substruct_location_diffs(self, ref_map: JsonMap, case_map: JsonMap):
+        sm = SequenceMatcher(None, ref_map.substruct_locations, case_map.substruct_locations)
+        
+        for op_type, i1, i2, j1, j2 in sm.get_opcodes():
+            if op_type == 'equal':
+                continue
+            
+            current = (ref_map.substruct_locations[i][0] for i in range(i1, i2))
+            target = (case_map.substruct_locations[j][1] for j in range(j1, j2))
+            
+            # Use weird range iterator to prevent pulling an extra item from current while zipping
+            for _, key_path, struct_sig in zip(_alt_range(i1, i2, j1, j2), current, target):
+                yield {'alt': key_path, 'to': struct_sig, self.CONGRUENT_DATA: case_map.items_from_signature(struct_sig)}
+            for key_path in current:
+                yield {'del': key_path}
+            for struct_sig in target:
+                yield {'add': struct_sig, self.CONGRUENT_DATA: case_map.items_from_signature(struct_sig)}
+    
+    def _scalar_diffs(self, ref_map: JsonMap, case_map: JsonMap):
+        sm = SequenceMatcher(None, ref_map.scalars, case_map.scalars)
+        
+        opcodes = sm.get_opcodes()
+        for op_type, i1, i2, j1, j2 in opcodes:
+            if op_type == 'equal':
+                continue
+            
+            current = (ref_map.scalars[i][0] for i in range(i1, i2))
+            target = (case_map.scalars[j][1] for j in range(j1, j2))
+            
+            # Use weird range iterator to prevent pulling an extra item from current while zipping
+            for _, key_path, value in zip(_alt_range(i1, i2, j1, j2), current, target):
+                # For scalars, this is intentionally different than substructure
+                yield {'set': key_path, 'to': value}
+            for key_path in current:
+                yield {'del': key_path}
+            for value in target:
+                yield {'ins': value}
+
+class QStringComparer:
+    """Utility to compare one URL query string with several others"""
+    
+    class Delta(tuple):
+        __slots__ = []
+        
+        def __new__(cls, edits, params, mods):
+            return tuple.__new__(cls, (edits, params, mods))
+        
+        @property
+        def edits(self):
+            return self[0]
+        
+        @property
+        def params(self):
+            return self[1]
+        
+        @property
+        def mods(self):
+            return self[2]
+    
+    def __init__(self, qsparams: SequenceType[Tuple[str, str]]):
+        super().__init__()
+        self.ref_qsparams = qsparams
+    
+    def diff(self, case_qsparams: SequenceType[Tuple[str, str]]):
+        sm = SequenceMatcher(None, self.ref_qsparams, case_qsparams)
+        opcodes = sm.get_opcodes()
+        delta_params = set()
+        edits = 0
+        for op_type, i1, i2, j1, j2 in opcodes:
+            if op_type == 'equal':
+                continue
+            
+            delta_params.update(self.ref_qsparams[i][0] for i in range(i1, i2))
+            delta_params.update(case_qsparams[j][0] for j in range(j1, j2))
+            
+            edits += max(i2 - i1, j2 - j1)
+        
+        delta_param_values = _group_dict(
+            (
+                param for param in case_qsparams
+                if param[0] in delta_params
+            ),
+            key=itemgetter(0),
+            value=itemgetter(1),
+        )
+        
+        return self.Delta(
+            edits,
+            delta_param_values,
+            tuple(self._mods(case_qsparams, opcodes))
+        )
+    
+    def _mods(self, case_qsparams, opcodes):
+        for op_type, i1, i2, j1, j2 in opcodes:
+            if op_type == 'equal':
+                continue
+            
+            current = (self.ref_qsparams[i] for i in range(i1, i2))
+            target = (case_qsparams[j] for j in range(j1, j2))
+            
+            for _, cur, targ in zip(_alt_range(i1, i2, j1, j2), current, target):
+                if cur[0] == targ[0]:
+                    yield {'field': cur[0], 'chg': cur[1], 'to': targ[1]}
+                else:
+                    yield {'field': cur[0], 'del': cur[1]}
+                    yield {'field': targ[0], 'add': targ[1]}
+            for field, value in current:
+                yield {'field': field, 'del': value}
+            for field, value in target:
+                yield {'field': field, 'add': value}
+
+JSON_TYPES = (type(None), str, int, float, list, dict) # list and dict must be the last two, in that order
+JsonType = IntEnum('JsonType', list(t.__name__ for t in JSON_TYPES))
+JsonType.is_collection = property(lambda self: self >= self.list)
+JsonType.construct = lambda self: JSON_TYPES[self.value - 1]()
+lookup_json_type = dict(zip(JSON_TYPES, JsonType)).get
+
+def _is_jsonic_body(body):
+    return not isinstance(body, (str, bytes))
+
+def _alt_range(i1, i2, j1, j2):
+    return range(min(i2 - i1, j2 - j1))

--- a/lib/intercom_test/utils.py
+++ b/lib/intercom_test/utils.py
@@ -14,6 +14,8 @@
 
 from contextlib import contextmanager
 import enum
+import functools
+import inspect
 import shutil
 import tempfile
 
@@ -168,3 +170,50 @@ class FilteredDictView:
     
     def __hash__(self, ):
         raise TypeError("unhashable type: '{}'".format(type(self).__qualname__))
+
+def attributed_error(cls):
+    """Expose exception instance constructor arguments (or specified names) as properties
+    
+    If the only purpose of the exception class constructor would be to generate
+    properties from the argument names, the ``ATTRIBUTES`` attribute of the
+    class can be assigned with either an iterable of :class:`str` or a single
+    :class:`str` (which will be :meth:`str.split`) to more concisely specify
+    the names to map to the arguments passed to the constructor.
+    """
+    ctor_sig = inspect.signature(cls.__init__)
+    prop_names = list(
+        name
+        for name, arg_info
+        in ctor_sig.parameters.items()
+        if arg_info.kind not in (arg_info.KEYWORD_ONLY, arg_info.VAR_KEYWORD)
+    )[1:]
+    if len(prop_names) == 1 and ctor_sig.parameters[prop_names[0]].kind is inspect.Parameter.VAR_POSITIONAL:
+        prop_names = cls.ATTRIBUTES
+        if isinstance(prop_names, str):
+            prop_names = prop_names.split()
+        else:
+            prop_names = list(prop_names)
+    
+    for i, prop_name in enumerate(prop_names):
+        value_extractor = functools.partial(_arg_extractor, i)
+        value_extractor.__doc__ = f"Index {i} argument to the constructor"
+        setattr(cls, prop_name, property(value_extractor))
+    
+    return cls
+
+def _arg_extractor(arg, exception):
+    return exception.args[arg]
+
+def optional_key(mapping, key):
+    """Syntactic sugar for working with dict keys that *might* be present
+    
+    Typical usage::
+    
+        for value in optional_key(d, 'answer'):
+            # Body executed once, with *value* assigned ``d['answer']``, if
+            # *d* contains ``'answer'``.  The body of the ``for`` is not
+            # executed at all, otherwise.
+            print(f"The answer: {value}")
+    """
+    if key in mapping:
+        yield mapping[key]

--- a/lib/intercom_test/version.py
+++ b/lib/intercom_test/version.py
@@ -1,4 +1,4 @@
-_nominal_version = "2.0.1"
+_nominal_version = "2.1.0"
 
 import os.path
 import subprocess

--- a/lib/intercom_test/yaml_tools.py
+++ b/lib/intercom_test/yaml_tools.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 from io import StringIO
+import packaging.version
 import yaml
 
 YAML_EXT = '.yml'
+PYYAML_REQUIRES_LOADER = packaging.version.parse('5.1') <= packaging.version.parse(yaml.__version__)
 
 def content_events(value):
     """Return an iterable of events presenting *value* within a YAML document"""
@@ -88,3 +90,10 @@ def value_from_event_stream(content_events, *, safe_loading=True):
         yaml.constructor.Constructor
     )()
     return node_constructor.construct_object(node, True)
+
+def get_load_fn(*, safe=True):
+    if safe:
+        return yaml.safe_load
+    if PYYAML_REQUIRES_LOADER:
+        return yaml.unsafe_load
+    return yaml.load

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,9 @@ setup(
     author_email='rtweeks21@gmail.com',
     license='Apache License 2.0',
     install_requires=[
-        'PyYAML >=3.11, <4',
+        'PyYAML >=3.11, <6',
         'pyasn1 >=0.4.2, <1',
+        'packaging >=20.8, <21',
     ],
     extras_require={
         'cli': ['docopt-subcommands>=3.0, <4', 'pick>=0.6.4, <1'],

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     install_requires=[
         'PyYAML >=3.11, <4',
         'pyasn1 >=0.4.2, <1',
+        'python-Levenshtein >=0.12, <1',
     ],
     extras_require={
         'cli': ['docopt-subcommands>=3.0, <4', 'pick>=0.6.4, <1'],

--- a/test/aws_http_tests.py
+++ b/test/aws_http_tests.py
@@ -1,0 +1,771 @@
+from intercom_test import aws_http as subject
+
+from base64 import b64encode
+import json
+from pathlib import Path
+from unittest.mock import patch
+from should_dsl import should, should_not
+
+def mock_run_serverless_print(self):
+    return json.loads(r"""
+        {
+          "service": {
+            "name": "sls-demo"
+          },
+          "frameworkVersion": "2",
+          "provider": {
+            "stage": "dev",
+            "region": "us-east-1",
+            "name": "aws",
+            "runtime": "python3.8",
+            "lambdaHashingVersion": "20201221",
+            "versionFunctions": true,
+            "variableSyntax": "\\${([^{}:]+?(?:\\(|:)(?:[^:{}][^{}]*?)?)}"
+          },
+          "functions": {
+            "hello": {
+              "handler": "test/aws_http_tests.hello",
+              "events": [
+                {
+                  "httpApi": {
+                    "path": "/greeting",
+                    "method": "get"
+                  }
+                },
+                {
+                  "httpApi": "get /greeting/{subject}"
+                },
+                {
+                  "httpApi": "post /greeting/{subject}"
+                },
+                {
+                  "httpApi": {
+                    "path": "/farewell/{proxy+}",
+                    "method": "*"
+                  }
+                },
+                {}
+              ],
+              "name": "test-hello"
+            },
+            "get_binary": {
+              "handler": "test/aws_http_tests.get_binary",
+              "events": [
+                {
+                  "httpApi": {
+                    "path": "/binary_document",
+                    "method": "get"
+                  }
+                }
+              ],
+              "name": "test-get_binary"
+            },
+            "problem_child": {
+              "handler": "test/aws_http_tests.bad_responder",
+              "events": [
+                {
+                  "httpApi": "GET /bad_response"
+                }
+              ],
+              "name": "test-problem_child"
+            },
+            "simple_responder": {
+              "handler": "test/aws_http_tests.simple_responder",
+              "events": [
+                {
+                  "httpApi": "GET /simple_response"
+                }
+              ],
+              "name": "test-simple_responder"
+            }
+          }
+        }
+    """)
+
+mocked_serverless = patch.object(
+    subject.ServerlessHandlerMapper,
+    '_get_rendered_serverless_config',
+    mock_run_serverless_print
+)
+
+def hello(event, context):
+    body = {
+        "message": "Go Serverless v1.0! Your function executed successfully!",
+        "input": event
+    }
+
+    response = {
+        "statusCode": 200,
+        "headers": {
+            "Content-Type": "application/json",
+        },
+        "multiValueHeaders": {
+            "X-Weird-Stuff": ['123', '456'],
+        },
+        "body": json.dumps(body)
+    }
+
+    return response
+
+def get_binary(event, context):
+    return {
+        'statusCode': 200,
+        'body': b64encode(b'123456789').decode('ASCII'),
+        'isBase64Encoded': True,
+    }
+
+def bad_responder(event, context):
+    return {
+        'statusCode': 200,
+    }
+
+def simple_responder(event, context):
+    return {'answer': 42}
+
+@mocked_serverless
+def test_unexpected_response_body():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    (tester, {
+        'method': 'GET',
+        'url': '/greeting',
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+        },
+    }) |should| throw(subject.UnexpectedResponseBody)
+
+@mocked_serverless
+def test_spec_missing_response_body():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    (tester, {
+        'method': 'GET',
+        'url': '/greeting',
+    }) |should_not| throw(subject.UnexpectedResponseBody)
+    
+    (tester, {
+        'method': 'GET',
+        'url': '/greeting',
+    }) |should| throw(Exception)
+    
+
+@mocked_serverless
+def test_bad_handler_response():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    (tester, {
+        'method': 'GET',
+        'url': '/bad_response',
+        'response body': {},
+    }) |should| throw(AssertionError)
+
+@mocked_serverless
+def test_static_path():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    tester({
+        'method': 'GET',
+        'url': '/greeting',
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'get',
+                        'path': '/greeting',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': {},
+                },
+                'rawPath': '/greeting',
+                'rawQueryString': '',
+                'headers': {},
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {},
+                'pathParameters': {},
+            },
+        },
+    })
+
+@mocked_serverless
+def test_query_string():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    tester({
+        'method': 'GET',
+        'url': '/greeting?name=Alice',
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'get',
+                        'path': '/greeting',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': {},
+                },
+                'rawPath': '/greeting',
+                'rawQueryString': 'name=Alice',
+                'headers': {},
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {
+                    'name': 'Alice',
+                },
+                'pathParameters': {},
+            },
+        },
+    })
+
+@mocked_serverless
+def test_query_string_multivalued():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    tester({
+        'method': 'GET',
+        'url': '/greeting?include=food&include=wine',
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'get',
+                        'path': '/greeting',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': {},
+                },
+                'rawPath': '/greeting',
+                'rawQueryString': 'include=food&include=wine',
+                'headers': {},
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {
+                    'include': 'food,wine',
+                },
+                'pathParameters': {},
+            },
+        },
+    })
+
+@mocked_serverless
+def test_path_parameter():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    tester({
+        'method': 'GET',
+        'url': '/greeting/cat',
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'get',
+                        'path': '/greeting/cat',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': {},
+                },
+                'rawPath': '/greeting/cat',
+                'rawQueryString': '',
+                'headers': {},
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {},
+                'pathParameters': {
+                    'subject': 'cat'
+                },
+            },
+        },
+    })
+
+@mocked_serverless
+def test_vartail_path_parameter():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    tester({
+        'method': 'GET',
+        'url': '/farewell/cruel/world',
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'get',
+                        'path': '/farewell/cruel/world',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': {},
+                },
+                'rawPath': '/farewell/cruel/world',
+                'rawQueryString': '',
+                'headers': {},
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {},
+                'pathParameters': {
+                    'proxy': 'cruel/world'
+                },
+            },
+        },
+    })
+
+@mocked_serverless
+def test_request_body():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    tester({
+        'method': 'POST',
+        'url': '/greeting/cat',
+        'request body': {'name': 'Fluffy'},
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'post',
+                        'path': '/greeting/cat',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': {},
+                },
+                'rawPath': '/greeting/cat',
+                'rawQueryString': '',
+                'headers': {
+                    'Content-Type': 'application/json',
+                },
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {},
+                'pathParameters': {
+                    'subject': 'cat'
+                },
+                'body': '{"name": "Fluffy"}',
+            },
+        },
+    })
+
+@mocked_serverless
+def test_binary_request_body():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    body = b'123456789'
+    tester({
+        'method': 'POST',
+        'url': '/greeting/cat',
+        'request body': body,
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'post',
+                        'path': '/greeting/cat',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': {},
+                },
+                'rawPath': '/greeting/cat',
+                'rawQueryString': '',
+                'headers': {},
+                'isBase64Encoded': True,
+                'stageVariables': {},
+                'queryStringParameters': {},
+                'pathParameters': {
+                    'subject': 'cat'
+                },
+                'body': b64encode(body).decode('ASCII'),
+            },
+        },
+    })
+
+@mocked_serverless
+def test_binary_response_body():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    body = b'123456789'
+    tester({
+        'method': 'GET',
+        'url': '/binary_document',
+        'response body': b'123456789',
+    })
+
+@mocked_serverless
+def test_unrouted():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    body = b'123456789'
+    (tester, {
+        'method': 'GET',
+        'url': '/no-such',
+        'response body': b'123456789',
+    }) |should| throw(subject.NoRoute)
+
+@mocked_serverless
+def test_response_header():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    tester({
+        'method': 'GET',
+        'url': '/greeting',
+        'response headers': {
+            'Content-Type': 'application/json',
+        },
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'get',
+                        'path': '/greeting',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': {},
+                },
+                'rawPath': '/greeting',
+                'rawQueryString': '',
+                'headers': {},
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {},
+                'pathParameters': {},
+            },
+        },
+    })
+
+@mocked_serverless
+def test_response_header_multivalued():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    tester({
+        'method': 'GET',
+        'url': '/greeting',
+        'response headers': [
+            ['X-Weird-Stuff', '123'],
+            ['X-Weird-Stuff', '456'],
+        ],
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'get',
+                        'path': '/greeting',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': {},
+                },
+                'rawPath': '/greeting',
+                'rawQueryString': '',
+                'headers': {},
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {},
+                'pathParameters': {},
+            },
+        },
+    })
+
+@mocked_serverless
+def test_response_header_multivalued_incomplete():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    (tester, {
+        'method': 'GET',
+        'url': '/greeting',
+        'response headers': [
+            ['X-Weird-Stuff', '123'],
+            ['X-Weird-Stuff', '456'],
+            ['X-Weird-Stuff', '789'],
+        ],
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'get',
+                        'path': '/greeting',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': {},
+                },
+                'rawPath': '/greeting',
+                'rawQueryString': '',
+                'headers': {},
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {},
+                'pathParameters': {},
+            },
+        },
+    }) |should| throw(AssertionError)
+
+@mocked_serverless
+def test_response_header_multivalued_excessive():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    (tester, {
+        'method': 'GET',
+        'url': '/greeting',
+        'response headers': [
+            ['X-Weird-Stuff', '123'],
+        ],
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'get',
+                        'path': '/greeting',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': {},
+                },
+                'rawPath': '/greeting',
+                'rawQueryString': '',
+                'headers': {},
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {},
+                'pathParameters': {},
+            },
+        },
+    }) |should| throw(AssertionError)
+
+def test_exception_messages():
+    exceptions = [
+        subject.InvalidPathTemplate('/{foo}bar/baz', 6),
+        subject.UnexpectedResponseBody(b'1234', b'4321'),
+        subject.UnexpectedResponseBody(b'1234' * 9, b'4321' * 9),
+        subject.UnexpectedResponseBody('Barbara', 'Yvonne'),
+    ]
+    
+    def str_does_not_error(e):
+        # (str, e) |should_not| throw(BaseException)
+        str(e)
+    
+    for e in exceptions:
+        yield (str_does_not_error, e)
+        
+def test_ServerlessHandlerMapper_project_dir_property():
+    service = subject.ServerlessHandlerMapper('test')
+    service.project_dir |should| be_kind_of(Path)
+
+def test_full_proxy_routing():
+    def full_proxy_routing(self):
+        sls_config = mock_run_serverless_print(self)
+        sls_config['functions']['hello']['events'][0]['httpApi'] = '*'
+        return sls_config
+    
+    import sys; from IPython.core.debugger import Pdb; sys.stdout.isatty() and Pdb().set_trace()
+    with patch.object(subject.ServerlessHandlerMapper, '_get_rendered_serverless_config', full_proxy_routing):
+        service = subject.ServerlessHandlerMapper('test')
+        service.map('patch', '/worn_pants')
+
+class WeakOpenAPIPathMatcherTests:
+    def test_path_template_segment_match_failure(self):
+        (subject.OpenAPIPathMatcher, 'get', '/{foo}bar/baz') |should| throw(subject.InvalidPathTemplate)
+
+    def test_path_nonterminal_vartail_path_template_segment(self):
+        (subject.OpenAPIPathMatcher, 'get', '/{foobar+}/baz') |should| throw(subject.InvalidPathTemplate)
+        
+
+@mocked_serverless
+def test_simple_handler_response():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    tester({
+        'method': 'GET',
+        'url': '/simple_response',
+        'response body': "{\"answer\": 42}",
+    })
+
+def test_OpenAPIPathMatcher_repr():
+    m = subject.OpenAPIPathMatcher('get', '/fuzzy')
+    repr(m)
+
+def test_genfunc_case_env():
+    def my_case_env(case):
+        yield
+    
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester(case_env=my_case_env)
+
+def test_contextmgr_case_env():
+    def my_case_env(case):
+        yield
+    
+    from contextlib import contextmanager
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester(case_env=contextmanager(my_case_env))
+
+@mocked_serverless
+def test_client_certificate():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    client_cert = {'degree': 'master clown'}
+    
+    tester({
+        'client certificate': client_cert,
+        'method': 'GET',
+        'url': '/greeting',
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'get',
+                        'path': '/greeting',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {
+                        'clientCert': client_cert,
+                    },
+                    'authorizer': {},
+                },
+                'rawPath': '/greeting',
+                'rawQueryString': '',
+                'headers': {},
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {},
+                'pathParameters': {},
+            },
+        },
+    })
+
+@mocked_serverless
+def test_authorizer():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    authorization = {'Vinny': {'limit': 10e6}}
+    
+    tester({
+        'method': 'GET',
+        'url': '/greeting',
+        'request authorization': authorization,
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'get',
+                        'path': '/greeting',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': authorization,
+                },
+                'rawPath': '/greeting',
+                'rawQueryString': '',
+                'headers': {},
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {},
+                'pathParameters': {},
+            },
+        },
+    })
+
+@mocked_serverless
+def test_request_headers():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    tester({
+        'method': 'GET',
+        'url': '/greeting',
+        'request headers': {
+            'X-Weird-Stuff': 'goop',
+        },
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'get',
+                        'path': '/greeting',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': {},
+                },
+                'rawPath': '/greeting',
+                'rawQueryString': '',
+                'headers': {
+                    'X-Weird-Stuff': 'goop',
+                },
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {},
+                'pathParameters': {},
+            },
+        },
+    })
+
+@mocked_serverless
+def test_str_request_body():
+    service = subject.ServerlessHandlerMapper('test')
+    tester = service.case_tester()
+    
+    tester({
+        'method': 'POST',
+        'url': '/greeting/neighbor',
+        'request body': "name=Fred",
+        'response body': {
+            'message': 'Go Serverless v1.0! Your function executed successfully!',
+            'input': {
+                'requestContext': {
+                    'http': {
+                        'method': 'post',
+                        'path': '/greeting/neighbor',
+                        'protocol': 'HTTP/1.1',
+                    },
+                    'authentication': {},
+                    'authorizer': {},
+                },
+                'rawPath': '/greeting/neighbor',
+                'rawQueryString': '',
+                'headers': {},
+                'isBase64Encoded': False,
+                'stageVariables': {},
+                'queryStringParameters': {},
+                'pathParameters': {
+                    'subject': 'neighbor',
+                },
+                'body': 'name=Fred',
+            },
+        },
+    })

--- a/test/http_best_matches_tests.py
+++ b/test/http_best_matches_tests.py
@@ -1,0 +1,548 @@
+from intercom_test import http_best_matches as subject
+from base64 import b64encode
+import json
+from should_dsl import should, should_not
+
+JSON_STR = """[{
+  "id": 1,
+  "first_name": "Jeanette",
+  "last_name": "Penddreth",
+  "email": "jpenddreth0@census.gov",
+  "gender": "Female",
+  "ip_address": "26.58.193.2"
+}, {
+  "id": 2,
+  "first_name": "Giavani",
+  "last_name": "Frediani",
+  "email": "gfrediani1@senate.gov",
+  "gender": "Male",
+  "ip_address": "229.179.4.212"
+}, {
+  "id": 3,
+  "first_name": "Noell",
+  "last_name": "Bea",
+  "email": "nbea2@imageshack.us",
+  "gender": "Female",
+  "ip_address": "180.66.162.255"
+}, {
+  "id": 4,
+  "first_name": "Willard",
+  "last_name": "Valek",
+  "email": "wvalek3@vk.com",
+  "gender": "Male",
+  "ip_address": "67.76.188.26"
+}]"""
+
+def new_json_data(mod=None):
+    data = json.loads(JSON_STR)
+    if mod is not None:
+        mod(data)
+    return data
+
+def make_case(method, url, body=None):
+    result = {'method': method, 'url': url}
+    if body is not None:
+        result['request body'] = body
+    return result
+
+def json_data_pair(mod):
+    return (new_json_data(), new_json_data(mod))
+
+def remove_index_2(data):
+    del data[2]
+
+def swap_at_indexes(a, b):
+    def swapper(data):
+        data[a], data[b] = data[b], data[a]
+    swapper.swaps = (a, b)
+    return swapper
+
+JsonType = subject.JsonType
+
+class JsonDescStrings:
+    CASE_DESCRIPTION = 'case description'
+    JSON_BODY_DELTAS = 'minimal JSON request body deltas'
+    SCALAR_BODY_DELTAS = 'closest request bodies'
+    ALTER_SUBSTRUCT = 'alter substructures'
+    REARRANGE_SUBSTRUCT = 'rearrange substructures'
+    ALTER_SCALARS = 'alter scalar values'
+    KNOWN_METHODS = 'available HTTP methods'
+    QSTRING_DELTAS = 'minimal query string deltas'
+    TARGET_QSPARAMS = 'params with differing value sequences'
+    GOOD_PATHS = 'closest URL paths'
+
+################################# TESTS #################################
+
+def test_report_incorrect_scalar_value():
+    def alter_request(request):
+        request[0]['first_name'] = 'Bob'
+    
+    case, request = (
+        make_case('post', '/foo', body)
+        for body in json_data_pair(alter_request)
+    )
+    db = subject.Database([case])
+    
+    suggestions = db.best_matches(request)
+    suggestions |should| be_instance_of(subject.AvailableJsonRequestBodiesReport)
+    
+    suggestions.diff_case_pairs |should| have(1).item
+    diff, case = suggestions.diff_case_pairs[0]
+    diff.structure_diffs |should| be_empty
+    diff.structure_location_diffs |should| be_empty
+    diff.scalar_diffs |should_not| be_empty
+    diff.scalar_diffs |should| equal_to(({'set': (0, 'first_name'), 'to': 'Jeanette'},))
+    
+    suggestions.as_jsonic_data() |should| equal_to({
+        JsonDescStrings.JSON_BODY_DELTAS: [
+            {
+                JsonDescStrings.CASE_DESCRIPTION: None,
+                'diff': {
+                    JsonDescStrings.ALTER_SCALARS: [
+                        {'set': (0, 'first_name'), 'to': 'Jeanette'},
+                    ]
+                },
+            }
+        ]
+    })
+
+def test_report_incorrect_scalar_type():
+    def alter_request(request):
+        request[0]['first_name'] = 7
+    
+    case, request = (
+        make_case('post', '/foo', body)
+        for body in json_data_pair(alter_request)
+    )
+    db = subject.Database([case])
+    
+    suggestions = db.best_matches(request)
+    suggestions |should| be_instance_of(subject.AvailableJsonRequestBodiesReport)
+    
+    suggestions.diff_case_pairs |should| have(1).item
+    diff, case = suggestions.diff_case_pairs[0]
+    diff.structure_diffs |should| have(2).items
+    diff.structure_diffs[0] |should| equal_to({'del': (0,)})
+    d = diff.structure_diffs[1]
+    d['add'][0] |should| equal_to(JsonType.dict)
+    d['add'][1] |should| equal_to({
+        ('first_name', JsonType.str),
+        ('last_name', JsonType.str),
+        ('id', JsonType.int),
+        ('gender', JsonType.str),
+        ('ip_address', JsonType.str),
+        ('email', JsonType.str),
+    })
+    
+    del request['request body'][0]
+    request['request body'].append(dict(
+        (fname, t.construct())
+        for fname, t in d['add'][1]
+    ))
+    
+    suggestions2 = db.best_matches(request)
+    suggestions2.diff_case_pairs |should| have(1).item
+    diff, case = suggestions2.diff_case_pairs[0]
+    diff.structure_diffs |should| have(0).items
+    
+    suggestions.as_jsonic_data() |should| equal_to({
+        JsonDescStrings.JSON_BODY_DELTAS: [
+            {
+                JsonDescStrings.CASE_DESCRIPTION: None,
+                'diff': {
+                    JsonDescStrings.ALTER_SUBSTRUCT: [
+                        {'del': (0,)},
+                        {'add': {
+                            'email': '',
+                            'ip_address': '',
+                            'first_name': '',
+                            'last_name': '',
+                            'gender': '',
+                            'id': 0,
+                        }},
+                    ]
+                },
+            }
+        ]
+    })
+
+def test_report_misplaced_substructure():
+    def alter_request(request):
+        request[2]['oops'] = request[3]
+        del request[3]
+    
+    case, request = (
+        make_case('post', '/foo', body)
+        for body in json_data_pair(alter_request)
+    )
+    db = subject.Database([case])
+    
+    suggestions = db.best_matches(request)
+    suggestions |should| be_instance_of(subject.AvailableJsonRequestBodiesReport)
+    
+    suggestions.diff_case_pairs |should| have(1).item
+    diff, case = suggestions.diff_case_pairs[0]
+    diff.structure_diffs |should| have(2).items
+    
+    d = diff.structure_diffs[0]
+    d |should| contain('alt')
+    d['alt'] |should| equal_to(())
+    d['to'][0] |should| be(JsonType.list)
+    d['to'][1] |should| equal_to((JsonType.dict,) * 4)
+    
+    d = diff.structure_diffs[1]
+    d |should| contain('alt')
+    d['alt'] |should| equal_to((2,))
+    d['to'][0] |should| be(JsonType.dict)
+    d['to'][1] |should| equal_to({
+        ('first_name', JsonType.str),
+        ('last_name', JsonType.str),
+        ('id', JsonType.int),
+        ('gender', JsonType.str),
+        ('ip_address', JsonType.str),
+        ('email', JsonType.str),
+    })
+    set(request['request body'][2]).difference(k for k, _ in d['to'][1]) |should| equal_to({'oops'})
+    
+    # In particular, note that there is no 'add' key in any of
+    # diff.structure_diffs; this indicates that the difference at key_path ()
+    # must come from something in request['request body'][2] (which also wants
+    # a structural change).
+    
+    request['request body'].append(request['request body'][2]['oops'])
+    del request['request body'][2]['oops']
+    
+    suggestions2 = db.best_matches(request)
+    suggestions2.diff_case_pairs |should| have(1).item
+    diff, case = suggestions2.diff_case_pairs[0]
+    diff.structure_diffs |should| have(0).items
+    
+    suggestions.as_jsonic_data() |should| equal_to({
+        JsonDescStrings.JSON_BODY_DELTAS: [
+            {
+                JsonDescStrings.CASE_DESCRIPTION: None,
+                'diff': {
+                    JsonDescStrings.ALTER_SUBSTRUCT: [
+                        {'alt': (), 'to': [{}, {}, {}, {}]},
+                        {'alt': (2,), 'to': {
+                            'email': '',
+                            'id': 0,
+                            'ip_address': '',
+                            'last_name': '',
+                            'first_name': '',
+                            'gender': ''
+                        }}
+                    ]
+                },
+            },
+        ]
+    })
+
+def test_swapped_substructure():
+    case, request = (
+        make_case('post', '/foo', body)
+        for body in json_data_pair(swap_at_indexes(0, 2))
+    )
+    case['request body'][0]['foo'] = request['request body'][2]['foo'] = 42
+    db = subject.Database([case])
+    
+    suggestions = db.best_matches(request)
+    suggestions |should| be_instance_of(subject.AvailableJsonRequestBodiesReport)
+    
+    suggestions.diff_case_pairs |should| have(1).item
+    diff, case = suggestions.diff_case_pairs[0]
+    diff.structure_diffs |should| have(0).items
+    diff.structure_location_diffs |should| have(2).items
+    
+    d = diff.structure_location_diffs[0]
+    d |should| contain('alt')
+    d['alt'] |should| equal_to((0,))
+    d['to'][0] |should| be(JsonType.dict)
+    d['to'][1] |should| equal_to({
+        ('first_name', JsonType.str),
+        ('last_name', JsonType.str),
+        ('id', JsonType.int),
+        ('gender', JsonType.str),
+        ('ip_address', JsonType.str),
+        ('email', JsonType.str),
+        ('foo', JsonType.int),
+    })
+    
+    d = diff.structure_location_diffs[1]
+    d |should| contain('alt')
+    d['alt'] |should| equal_to((2,))
+    d['to'][0] |should| be(JsonType.dict)
+    d['to'][1] |should| equal_to({
+        ('first_name', JsonType.str),
+        ('last_name', JsonType.str),
+        ('id', JsonType.int),
+        ('gender', JsonType.str),
+        ('ip_address', JsonType.str),
+        ('email', JsonType.str),
+    })
+    
+    suggestions.as_jsonic_data() |should| equal_to({
+        JsonDescStrings.JSON_BODY_DELTAS: [
+            {
+                JsonDescStrings.CASE_DESCRIPTION: None,
+                'diff': {
+                    JsonDescStrings.REARRANGE_SUBSTRUCT: [
+                        {'alt': (0,), 'to': {
+                            'id': 0,
+                            'foo': 0,
+                            'gender': '',
+                            'first_name': '',
+                            'last_name': '',
+                            'ip_address': '',
+                            'email': ''
+                        }},
+                        {'alt': (2,), 'to': {
+                            'id': 0,
+                            'gender': '',
+                            'first_name': '',
+                            'last_name': '',
+                            'ip_address': '',
+                            'email': ''
+                        }},
+                    ]
+                }
+            }
+        ]
+    })
+
+def test_body_string_diff():
+    case, request = (
+        make_case('post', '/get_bar_info', "name={}".format(name))
+        for name in ('Cheers', 'Cheers!')
+    )
+    db = subject.Database([case])
+    
+    suggestions = db.best_matches(request)
+    suggestions |should| be_instance_of(subject.AvailableScalarRequestBodiesReport)
+    
+    suggestions.test_cases |should| have(1).item
+    suggestions.test_cases[0]['request body'] |should| equal_to(case['request body'])
+    
+    suggestions.as_jsonic_data() |should| equal_to({
+        JsonDescStrings.SCALAR_BODY_DELTAS: [
+            {
+                JsonDescStrings.CASE_DESCRIPTION: None,
+                'request body': case['request body'],
+            }
+        ]
+    })
+
+def test_body_binary_diff():
+    case, request = (
+        make_case('post', '/fingerprint', data)
+        for data in (b'123456789', b'123654789')
+    )
+    db = subject.Database([case])
+    
+    suggestions = db.best_matches(request)
+    suggestions |should| be_instance_of(subject.AvailableScalarRequestBodiesReport)
+    
+    suggestions.test_cases |should| have(1).item
+    suggestions.test_cases[0]['request body'] |should| equal_to(case['request body'])
+    
+    suggestions.as_jsonic_data() |should| equal_to({
+        JsonDescStrings.SCALAR_BODY_DELTAS: [
+            {
+                JsonDescStrings.CASE_DESCRIPTION: None,
+                'request body': b64encode(case['request body']).decode('ASCII'),
+                'isBase64Encoded': True,
+            }
+        ]
+    })
+
+def test_http_method_suggestion():
+    case = make_case('post', '/foo')
+    request = make_case('get', '/foo')
+    db = subject.Database([case])
+    
+    suggestions = db.best_matches(request)
+    suggestions |should| be_instance_of(subject.AvailableHttpMethodsReport)
+    
+    suggestions.methods |should| equal_to({'post'})
+    
+    suggestions.as_jsonic_data() |should| equal_to({
+        JsonDescStrings.KNOWN_METHODS: ['post']
+    })
+
+def test_missing_query_param():
+    case = make_case('get', '/foo?bar=BQ')
+    request = make_case('get', '/foo')
+    db = subject.Database([case])
+    
+    suggestions = db.best_matches(request)
+    suggestions |should| be_instance_of(subject.AvailableQueryStringParamsetsReport)
+    
+    suggestions.deltas |should| have(1).item
+    
+    d = suggestions.deltas[0]
+    d[0] |should| respond_to('params')
+    d[0] |should| respond_to('mods')
+    d[0].params |should| equal_to({'bar': ['BQ']})
+    d[0].mods |should| equal_to(({'field': 'bar', 'add': 'BQ'},))
+    
+    suggestions.as_jsonic_data() |should| equal_to({
+        JsonDescStrings.QSTRING_DELTAS: [
+            {
+                JsonDescStrings.CASE_DESCRIPTION: None,
+                'diff': {
+                    JsonDescStrings.TARGET_QSPARAMS: {
+                        'bar': ['BQ'],
+                    },
+                    'mods': (
+                        {'field': 'bar', 'add': 'BQ'},
+                    )
+                }
+            }
+        ]
+    })
+
+def test_wrong_query_param_value():
+    case = make_case('get', '/foo?bar=BQ')
+    request = make_case('get', '/foo?bar=Cheers')
+    db = subject.Database([case])
+    
+    suggestions = db.best_matches(request)
+    suggestions |should| be_instance_of(subject.AvailableQueryStringParamsetsReport)
+    
+    suggestions.deltas |should| have(1).item
+    
+    d = suggestions.deltas[0]
+    d[0] |should| respond_to('params')
+    d[0] |should| respond_to('mods')
+    d[0].params |should| equal_to({'bar': ['BQ']})
+    d[0].mods |should| equal_to(({'field': 'bar', 'chg': 'Cheers', 'to': 'BQ'},))
+    
+    suggestions.as_jsonic_data() |should| equal_to({
+        JsonDescStrings.QSTRING_DELTAS: [
+            {
+                JsonDescStrings.CASE_DESCRIPTION: None,
+                'diff': {
+                    JsonDescStrings.TARGET_QSPARAMS: {
+                        'bar': ['BQ'],
+                    },
+                    'mods': (
+                        {'field': 'bar', 'chg': 'Cheers', 'to': 'BQ'},
+                    )
+                }
+            }
+        ]
+    })
+
+def test_extra_query_param():
+    case = make_case('get', '/foo?bar=BQ')
+    request = make_case('get', '/foo?bar=BQ&bar=Cheers')
+    db = subject.Database([case])
+    
+    suggestions = db.best_matches(request)
+    suggestions |should| be_instance_of(subject.AvailableQueryStringParamsetsReport)
+    
+    suggestions.deltas |should| have(1).item
+    
+    d = suggestions.deltas[0]
+    d[0] |should| respond_to('params')
+    d[0] |should| respond_to('mods')
+    d[0].params |should| equal_to({'bar': ['BQ']})
+    d[0].mods |should| equal_to(({'field': 'bar', 'del': 'Cheers'},))
+    
+    suggestions.as_jsonic_data() |should| equal_to({
+        JsonDescStrings.QSTRING_DELTAS: [
+            {
+                JsonDescStrings.CASE_DESCRIPTION: None,
+                'diff': {
+                    JsonDescStrings.TARGET_QSPARAMS: {
+                        'bar': ['BQ'],
+                    },
+                    'mods': (
+                        {'field': 'bar', 'del': 'Cheers'},
+                    )
+                }
+            }
+        ]
+    })
+
+def test_misordered_query_params():
+    case = make_case('get', '/foo?bar=BQ&bar=Cheers')
+    request = make_case('get', '/foo?bar=Cheers&bar=BQ')
+    db = subject.Database([case])
+    
+    suggestions = db.best_matches(request)
+    suggestions |should| be_instance_of(subject.AvailableQueryStringParamsetsReport)
+    
+    suggestions.deltas |should| have(1).item
+    
+    d = suggestions.deltas[0]
+    d[0] |should| respond_to('params')
+    d[0] |should| respond_to('mods')
+    d[0].params |should| equal_to({'bar': ['BQ', 'Cheers']})
+    d[0].mods |should| equal_to(({'field': 'bar', 'add': 'BQ'}, {'field': 'bar', 'del': 'BQ'}))
+    
+    suggestions.as_jsonic_data() |should| equal_to({
+        JsonDescStrings.QSTRING_DELTAS: [
+            {
+                JsonDescStrings.CASE_DESCRIPTION: None,
+                'diff': {
+                    JsonDescStrings.TARGET_QSPARAMS: {
+                        'bar': ['BQ', 'Cheers'],
+                    },
+                    'mods': (
+                        {'field': 'bar', 'add': 'BQ'},
+                        {'field': 'bar', 'del': 'BQ'},
+                    )
+                }
+            }
+        ]
+    })
+
+def test_ignores_order_between_query_params():
+    case = make_case('get', '/foo?bar=BQ&baz=Cheers&zapf=1')
+    request = make_case('get', '/foo?baz=Cheers&bar=BQ&zapf=2')
+    db = subject.Database([case])
+    
+    suggestions = db.best_matches(request)
+    suggestions |should| be_instance_of(subject.AvailableQueryStringParamsetsReport)
+    
+    suggestions.deltas |should| have(1).item
+    
+    d = suggestions.deltas[0]
+    d[0] |should| respond_to('params')
+    d[0] |should| respond_to('mods')
+    d[0].params |should| equal_to({'zapf': ['1']})
+    d[0].mods |should| equal_to(({'field': 'zapf', 'chg': '2', 'to': '1'},))
+    
+    # The as_jsonic_data is covered in test_wrong_query_param_value
+    pass
+
+def test_wrong_path():
+    cases = [
+        make_case('get', '/food/hippopatamus'),
+        make_case('get', '/food'),
+        make_case('get', '/food/cat'),
+        make_case('get', '/food/goat'),
+        make_case('get', '/food/dog'),
+        make_case('get', '/food/pig'),
+        make_case('get', '/food/brachiosaurus'),
+    ]
+    request = make_case('get', '/foo')
+    db = subject.Database(cases)
+    
+    suggestions = db.best_matches(request)
+    suggestions |should| be_instance_of(subject.AvailablePathsReport)
+    
+    suggestions.test_case_groups |should| have(5).items
+    tcgs = suggestions.test_case_groups
+    list(g[0] for g in tcgs) |should| include_all_of(c['url'] for c in cases[1:6])
+    
+    suggestions.as_jsonic_data() |should| equal_to({
+        JsonDescStrings.GOOD_PATHS: [
+            ('/food', []),
+            ('/food/cat', []),
+            ('/food/dog', []),
+            ('/food/pig', []),
+            ('/food/goat', []), # Note this is moved later in the list because of higher edit distance
+        ]
+    })


### PR DESCRIPTION
* Fixes PyYAML dependency on old version tagged with CVE-2017-18342.
* Adds `hjx-stubber` subcommand to `icy-test` to support common HTTP-exchanged JSON in non-Python stacks.
* Adds support for testing Serverless HTTP API service provider projects targeting AWS.